### PR TITLE
Fixed guillaume-nargeot/hpc-coveralls#34 (Added test modules to package)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -930,9 +930,6 @@ expected-test-failures:
     # https://github.com/mvoidex/hdocs/issues/3
     - hdocs
 
-    # https://github.com/guillaume-nargeot/hpc-coveralls/issues/34
-    - hpc-coveralls
-
 # Haddocks which are expected to fail. Same concept as expected test failures.
 expected-haddock-failures:
     # https://github.com/acw/bytestring-progress/issues/4


### PR DESCRIPTION
The test modules TestHpcCoverallsLix and TestHpcCoverallsUtil should now be included in the sdist package.