### PR TITLE
Add bcrypt package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -684,6 +684,9 @@ packages:
     "Tomas Carnecky":
         - rethinkdb-client-driver
 
+    "Alexandr Kurilin alex@kurilin.net @alex_kurilin":
+        - bcrypt
+
     "Stackage upper bounds":
 
         # Force a specific version that's compatible with transformers 0.3


### PR DESCRIPTION
This adds the bcrypt package to stackage. I tested it locally against stackage LTS 1.0 on my yesod project and it seemed to not cause any trouble at version 0.0.5.

Let me know if I'm missing anything else in the PR.