### PR TITLE
Add Hakyll to Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -152,6 +152,7 @@ packages:
     "Jasper Van der Jeugt":
         - blaze-html
         - blaze-markup
+        - hakyll
         - stylish-haskell
 
     "Antoine Latter":


### PR DESCRIPTION
The latest version (`4.6.5.0`) should work with the latest versions of all dependencies.