### PR TITLE
Add http-media and cabal-test-quickcheck

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -706,6 +706,10 @@ packages:
     "Leon Mergen leon@solatis.com":
         - network-attoparsec
 
+    "Timothy Jones git@zmthy.io @zmthy":
+        - cabal-test-quickcheck
+        - http-media
+
     "Stackage upper bounds":
 
         # Force a specific version that's compatible with transformers 0.3


### PR DESCRIPTION
I've been asked to add http-media so others can depend on it. The cabal-test-quickcheck package is a testing dependency.