### PR TITLE
Add string-conversions

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -713,13 +713,16 @@ packages:
     "Timothy Jones git@zmthy.io @zmthy":
         - cabal-test-quickcheck
         - http-media
-        
+
     "Greg V greg@unrelenting.technology @myfreeweb":
         - gitson
         - pcre-heavy
 
     "Francesco Mazzoli f@mazzo.li @bitonic":
         - language-c-quote
+
+    "Sönke Hahn soenkehahn@gmail.com @soenkehahn":
+        - string-conversions
 
     "Stackage upper bounds":
 


### PR DESCRIPTION
As I understand `string-conversions` is already included as a dependency of other packages, but I'd be happy to be the official stackage maintainer.