### PR TITLE
remove upper bound for https://github.com/d12frosted/CanonicalPath/issues3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -758,9 +758,6 @@ packages:
         # https://github.com/fpco/stackage/issues/426
         - utf8-string < 1
 
-        # https://github.com/d12frosted/CanonicalPath/issues/3
-        - system-canonicalpath < 0.3
-
         # https://github.com/fpco/stackage/issues/440
         - th-orphans < 0.9
         - file-location < 0.4.7


### PR DESCRIPTION
https://github.com/d12frosted/CanonicalPath/issues/3 was resolved, so I think now it's safe to remove upper bound for it. 