### PR TITLE
Remove quickpull and barecheck

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -122,9 +122,7 @@ packages:
         - kure
 
     "Omari Norman <omari@smileystation.com>":
-        - barecheck
         - rainbow
-        - quickpull
         - multiarg
         - prednote
         - cartel


### PR DESCRIPTION
It's not worth upgrading these to support QuickCheck 2.8, as I no
longer use these packages.  I have removed the dependencies on these
packages from my packages; no other Stackage packages depended on
them.

These packages were intended to solve two evils that often arise
during testing (orphan instances and Template Haskell); however, I
have reluctantly concluded that those evils are the lesser of other
evils so these packages are no longer needed.