### PR TITLE
Adding packages for maintainer Brendan Hay

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -742,7 +742,7 @@ packages:
 
     "Oleg Grenrus oleg.grenrus@iki.fi @phadej":
         - waitra
-    
+
     "Adam C. Foltzer acfoltzer@galois.com @acfoltzer":
         - gitrev
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -877,6 +877,8 @@ package-flags:
         old-locale: true
     tttool:
         old-locale: true
+    amazonka-core:
+        old-locale: true
 
     hxt:
         network-uri: true

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -749,6 +749,58 @@ packages:
     "Luke Taylor tekul.hs@gmail.com @tekul":
         - jose-jwt
 
+    "Brendan Hay brendan.g.hay@gmail.com @brendanhay":
+        - amazonka
+        - amazonka-core
+        - amazonka-autoscaling
+        - amazonka-cloudformation
+        - amazonka-cloudfront
+        - amazonka-cloudhsm
+        - amazonka-cloudsearch-domains
+        - amazonka-cloudsearch
+        - amazonka-cloudtrail
+        - amazonka-cloudwatch-logs
+        - amazonka-cloudwatch
+        - amazonka-codedeploy
+        - amazonka-cognito-identity
+        - amazonka-cognito-sync
+        - amazonka-config
+        - amazonka-datapipeline
+        - amazonka-directconnect
+        - amazonka-dynamodb
+        - amazonka-ec2
+        - amazonka-ecs
+        - amazonka-elasticache
+        - amazonka-elasticbeanstalk
+        - amazonka-elastictranscoder
+        - amazonka-elb
+        - amazonka-emr
+        - amazonka-glacier
+        - amazonka-iam
+        - amazonka-importexport
+        - amazonka-kinesis
+        - amazonka-kms
+        - amazonka-lambda
+        - amazonka-opsworks
+        - amazonka-rds
+        - amazonka-redshift
+        - amazonka-route53-domains
+        - amazonka-route53
+        - amazonka-s3
+        - amazonka-sdb
+        - amazonka-ses
+        - amazonka-sns
+        - amazonka-sqs
+        - amazonka-ssm
+        - amazonka-storagegateway
+        - amazonka-sts
+        - amazonka-support
+        - amazonka-swf
+        - ede
+        - pagerduty
+        - semver
+        - text-manipulate
+
     "Stackage upper bounds":
 
         # Force a specific version that's compatible with transformers 0.3


### PR DESCRIPTION
Initially encompassing:

* [amazonka-*](http://hackage.haskell.org/package/amazonka): Full AWS SDK library suite.
* [pagerduty](http://hackage.haskell.org/package/pagerduty): PagerDuty API bindings.
* [ede](http://hackage.haskell.org/package/ede): Templating language similar to Liquid/Jinja2.
* [semver](http://hackage.haskell.org/package/semver): Semantic versioning structure.
* [text-manipulate](http://hackage.haskell.org/package/text-manipulate): Commonly used recasing/manipulation of `Text` streams.