### PR TITLE
binary-list upper bound should no longer be necessary

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -861,9 +861,6 @@ packages:
         # https://github.com/fpco/stackage/issues/497
         - primitive < 0.6
 
-        # https://github.com/Daniel-Diaz/binary-list/issues/2
-        - binary-list < 1.1
-
 # Package flags are applied to individual packages, and override the values of
 # global-flags
 package-flags:


### PR DESCRIPTION
Issue https://github.com/Daniel-Diaz/binary-list/issues/2 should be solved by now.