### PR TITLE
add hledger-web

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -527,6 +527,7 @@ packages:
 
     "Simon Michael <simon@joyful.com>":
         - hledger
+        - hledger-web
 
     "Mihai Maruseac <mihai.maruseac@gmail.com>":
         - io-manager


### PR DESCRIPTION
hledger-web is the web app/GUI version of hledger. I don't really know a better way to add it than submit a PR and hope the buildbots are kind. Tips welcome.
