### PR TITLE
add git-annex

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -490,6 +490,9 @@ packages:
         - MusicBrainz
         - DAV
         - hopenpgp-tools
+        
+    "Joey Hess <id@joeyh.name>":
+        - git-annex
 
     # https://github.com/fpco/stackage/issues/160
     "Ketil Malde":


### PR DESCRIPTION
@nomeata suggested I add it, and this is fine by me.

git-annex is a leaf, non-library package, and in the http://hackage.haskell.org/packages/top list, after filtering out the core haskell ecosystem, git-annex is near the top of the list of remaining packages. For whatever that might be worth.