### PR TITLE
Add amazonka-ml (Amazon Machine Learning Service SDK)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -801,6 +801,7 @@ packages:
         - amazonka-kinesis
         - amazonka-kms
         - amazonka-lambda
+        - amazonka-ml
         - amazonka-opsworks
         - amazonka-rds
         - amazonka-redshift


### PR DESCRIPTION
Adds the `amazonka-ml` library for the recently released [Amazon Machine Learning Service](http://aws.amazon.com/machine-learning/).