### PR TITLE
Add annotated-wl-pprint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -890,6 +890,9 @@ packages:
     "Will Coster <willcoster@gmail.com> @fimad":
         - scalpel
 
+   "David Raymond Christiansen <david@davidchristiansen.dk> @david-christiansen"
+        - annotated-wl-pprint
+
     "Stackage upper bounds":
         # GHC 7.8 uppdate bound
         - haddock-api < 2.16


### PR DESCRIPTION
This is a version of the Wadler-Leijen pretty-printer with optional semantic annotations on pretty-printer documents. It's used by Idris, which we'd like to make build with LTS Haskell.

This is my first submission to Stackage, so please tell me if I'm doing it wrong!