### PR TITLE
Remove cabal-test-quickcheck, restore http-media

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -783,7 +783,6 @@ packages:
         - network-anonymous-i2p
 
     "Timothy Jones git@zmthy.io @zmthy":
-        - cabal-test-quickcheck
         - http-media
 
     "Greg V greg@unrelenting.technology @myfreeweb":
@@ -1247,9 +1246,6 @@ expected-test-failures:
 
     # https://github.com/jberryman/directory-tree/issues/4
     - directory-tree
-
-    # https://github.com/zmthy/http-media/issues/11
-    - http-media
 
     # https://github.com/ekmett/semigroupoids/issues/18
     - semigroupoids


### PR DESCRIPTION
Packages tested with cabal-test-quickcheck cannot pass on all of the
required platforms: it requires that Cabal and cabal-install be on the
same side of version 1.19, but a build against GHC 7.8 will tend to use
Cabal-1.18 with cabal-install-1.20 or higher. As such, the library has
been removed. The http-media package, which used cabal-test-quickcheck,
is now expected to build its test suite and pass all tests.