### PR TITLE
Adds bitcoin-api-extra

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -785,6 +785,7 @@ packages:
     "Leon Mergen leon@solatis.com @solatis":
         - base58string
         # - bitcoin-api GHC 7.10, via wreq
+        # - bitcoin-api-extra GHC 7.10, via wreq
         - bitcoin-block
         - bitcoin-script
         - bitcoin-tx


### PR DESCRIPTION
Added commented out since it depends upon bitcoin-api, which doesn't build on GHC 7.10 via wreq. 