### PR TITLE
Re-enable codex (#415).

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -741,9 +741,8 @@ packages:
         - unbound-generics
 
     "Alois Cochard alois.cochard@gmail.com @aloiscochard":
-        # https://github.com/fpco/stackage/issues/415
-        # - codex
-        #- machines-directory GHC 7.10
+        - codex
+        - machines-directory
         - machines-io
         - machines-process
         # on behalf of Bryan O'Sullivan @bos


### PR DESCRIPTION
Surprisingly I did not get any error building `machines-directory` for 7.10, let's see what Travis says.