### PR TITLE
Update build-constraints.yaml -- adding libraries

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -996,6 +996,10 @@ packages:
 
     "Michael Thompson <what_is_it_to_do_anything@yahoo.com> @michaelt":
         - pipes-text
+    
+    "Justin Le <justin@jle.im> @mstksg":
+        - auto
+        - tagged-binary
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/476


### PR DESCRIPTION
Hi,

Adding my libraries `auto` (Denotative programming platform) and `tagged-binary` (typed serialization for usage through binary sockets/communication channels).  I'm not totally sure if it's the sort of thing Stackage is looking for (is there a guide somewhere?), but figured that it'd be worth submitting a request to see.

Thanks!