### PR TITLE
Remove deprecated package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -562,7 +562,6 @@ packages:
         - imagesize-conduit
         - json-schema
         - multipart
-        - regular-xmlpickler
         - rest-client
         - rest-core
         - rest-gen


### PR DESCRIPTION
regular-xmlpickler has no reverse dependencies and is superseded by generic-xmlpickler.
