### PR TITLE
Reenable metrics package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1020,8 +1020,7 @@ packages:
         - flowdock
         - growler
         - engine-io-growler
-        # https://github.com/iand675/metrics/issues/2
-        # - metrics
+        - metrics
         - pipes-wai
         - serf
         - uri-templater


### PR DESCRIPTION
I've updated metrics to 0.3.0.0 and tested it against stackage, should be fixed now.