### PR TITLE
The serversession family of packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -399,7 +399,8 @@ packages:
         - serversession-backend-persistent
         - serversession-backend-redis
         - serversession-frontend-snap
-        - serversession-frontend-wai
+        # <https://github.com/singpolyma/wai-session/pull/7>
+        # - serversession-frontend-wai
         - serversession-frontend-yesod
         - thumbnail-plus
         - yesod-fb

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -394,6 +394,13 @@ packages:
         - fb-persistent
         - mangopay
         - nonce
+        - serversession
+        - serversession-backend-acid-state
+        - serversession-backend-persistent
+        - serversession-backend-redis
+        - serversession-frontend-snap
+        - serversession-frontend-wai
+        - serversession-frontend-yesod
         - thumbnail-plus
         - yesod-fb
         - yesod-auth-fb


### PR DESCRIPTION
@snoyberg IIRC, neither `acid-state` nor `wai-session` are available on Stackage.  How should I proceed?  Should I comment out packages depending on them?