### PR TITLE
Add back protocol-buffers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1119,11 +1119,10 @@ packages:
     "koral koral@mailoo.org @k0ral":
         - timerep
 
-    # Doesn't compile on GHC 7.10, see: https://github.com/fpco/stackage/pull/661
-    #    "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
-    #    - protocol-buffers
-    #    - protocol-buffers-descriptor
-    #    - hprotoc
+    "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
+        - protocol-buffers
+        - protocol-buffers-descriptor
+        - hprotoc
 
     "Rob O'Callahan ropoctl@gmail.com":
         - pipes-fastx

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1121,8 +1121,8 @@ packages:
 
     "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
         - protocol-buffers
-        - protocol-buffers-descriptor
         - hprotoc
+        - protocol-buffers-descriptor
 
     "Rob O'Callahan ropoctl@gmail.com":
         - pipes-fastx


### PR DESCRIPTION
Version 2.1.1 builds fine with GHC 7.10 now https://travis-ci.org/k-bx/protocol-buffers/builds/69730426