### PR TITLE
Add John Lenz's packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1130,6 +1130,11 @@ packages:
         - seqalign
         - thermonuc
         - xlsior
+    "John Lenz <wuzzeb@gmail.com> @wuzzeb":
+        - yesod-auth-account
+        - yesod-static-angular
+        - hspec-webdriver
+        - webdriver-angular
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
@@ -1393,6 +1398,8 @@ expected-test-failures:
     # Requires a running webdriver server
     - webdriver
     - webdriver-snoy
+    - hspec-webdriver
+    - webdriver-angular
 
     # Weird conflicts with sandboxing
     - ghc-mod


### PR DESCRIPTION
The two webdriver packages require selenium server to be running so I added
them to the ignore list.  I have manually executed the test suite with
nightly-2015-07-08 and it passes for these packages.