### PR TITLE
add range package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1153,6 +1153,9 @@ packages:
         - hlibsass
         - hsass
 
+    "Robert Massaioli robertmassaioli@gmail.com":
+        - range
+
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6


### PR DESCRIPTION
Adding the `range` package, of which I am co-maintainer. Robert Massaioli asked me to add it under his name.