### PR TITLE
Disable netwire to upgrade 5 other packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1087,7 +1087,8 @@ packages:
         - nationstates
 
     "Mathieu Boespflug <mboes@tweag.net> @mboes":
-        - netwire
+        # https://github.com/fpco/stackage/issues/590
+        # netwire
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":
@@ -1169,13 +1170,10 @@ packages:
         - smoothie < 0.3.2
 
         # https://github.com/fpco/stackage/issues/588
-        - semigroupoids < 4.5
-        - semigroupoid-extras < 4.5
-        - lens < 4.10
+        - lens < 4.12
 
         # https://github.com/fpco/stackage/issues/590
-        - bifunctors < 5
-        - profunctors < 5
+        - profunctors < 5.1
 
         # https://github.com/fpco/stackage/issues/602
         - errors < 2


### PR DESCRIPTION
25 days since the netwire upper bound was added in #590. What do you think @snoyberg?
