### PR TITLE
Add IHaskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1222,6 +1222,19 @@ packages:
     "Matthew Pickering <matthewtpickering@gmail.com> @mpickering":
         - refact
         - servant-pandoc
+    
+    "Andrew Gibiansky <andrew.gibiansky@gmail.com> @gibiansky":
+        - ihaskell
+        - ihaskell-aeson
+        - ihaskell-basic
+        - ihaskell-blaze
+        - ihaskell-charts
+        - ihaskell-diagrams
+        - ihaskell-hatex
+        - ihaskell-juicypixels
+        - ihaskell-magic
+        - ihaskell-rlangqq  
+        - ihaskell-static-canvas
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537


### PR DESCRIPTION
I'd like to finally add IHaskell to Stackage. I believe it builds as `stack` has managed to build it using the 7/28 nightly with a few extra dependencies that are not included in Stackage.

I'm not completely sure what I need to do to make sure IHaskell can be added to stackage (besides agree with to the maintainer's agreement), so let me know what I should be doing.