### PR TITLE
Fixing IHaskell; adding other IHaskell dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1235,19 +1235,20 @@ packages:
         - refact
         - servant-pandoc
 
-    #"Andrew Gibiansky <andrew.gibiansky@gmail.com> @gibiansky":
-        # https://github.com/gibiansky/IHaskell/issues/547
-        #- ihaskell
-        #- ihaskell-aeson
-        #- ihaskell-basic
-        #- ihaskell-blaze
-        #- ihaskell-charts
-        #- ihaskell-diagrams
-        #- ihaskell-hatex
-        #- ihaskell-juicypixels
-        #- ihaskell-magic
-        #- ihaskell-rlangqq
-        #- ihaskell-static-canvas
+    "Andrew Gibiansky <andrew.gibiansky@gmail.com> @gibiansky":
+        - ihaskell
+        - ihaskell-aeson
+        - ihaskell-basic
+        - ihaskell-blaze
+        - ihaskell-charts
+        - ihaskell-diagrams
+        - ihaskell-hatex
+        - ihaskell-juicypixels
+        - ihaskell-magic
+        - ihaskell-rlangqq
+        - ihaskell-static-canvas
+        - ghc-parser
+        - ipython-kernel
 
     "Andrés Sicard-Ramírez <asr@eafit.edu.co> @asr":
         - Agda


### PR DESCRIPTION
I've fixed the issue that caused IHaskell to be removed (I think); [issue](https://github.com/gibiansky/IHaskell/issues/547) closed.

Also adding `ghc-parser` and `ipython-kernel`, two integral packages for IHaskell.

Is there some way I can test things better to make sure this doesn't break stackage again?