### PR TITLE
Remove upper bound on aeson & attoparsec

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -13,7 +13,7 @@ packages:
         - keter
         - markdown
         - mime-mail
-        - mime-mail-ses
+        - mime-mail-sesa
         - monadcryptorandom
         - network-conduit-tls
         - persistent
@@ -1287,7 +1287,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/572
         - attoparsec < 0.13
-        - aeson < 0.8.1.0
 
         # https://github.com/fpco/stackage/issues/682
         - vector < 0.11

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1285,9 +1285,6 @@ packages:
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6
 
-        # https://github.com/fpco/stackage/issues/572
-        - attoparsec < 0.13
-
         # https://github.com/fpco/stackage/issues/682
         - vector < 0.11
 


### PR DESCRIPTION
I'm not entirely sure of the process here, so please let me know if I'm doing something wrong! I chased up on the packages that still needed their aeson upper bounds to be bumped (see https://github.com/fpco/stackage/issues/572), so it seems the upper bound can be removed.

