### PR TITLE
Add hidapi.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1296,6 +1296,7 @@ packages:
         - GLFW-b
 
     "Niklas Hambüchen mail@nh2.me @nh2":
+        - hidapi
         - iso8601-time
 
     "Stackage upper bounds":


### PR DESCRIPTION
Needs the `libudev-dev` package (on Ubuntu/Debian).

@snoyberg Can you remind me, what's the approach with system libraries?