### PR TITLE
Add `ig` package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1317,6 +1317,9 @@ packages:
     "Trevor Elliott <awesomelyawesome@gmail.com> @elliottt":
         - irc
 
+    "Dennis Gosnell <cdep.illabout@gmail.com> @cdepillabout":
+        - ig
+
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6


### PR DESCRIPTION
This pull request adds the [ig](https://hackage.haskell.org/package/ig) package.

The github repository for this pacakge is [here](https://github.com/prowdsponsor/ig).

I am not the maintainer of this package but I am willing to make fixes when/if the package stops building.  It's possible that @alanpog or @meteficha (the actual maintainers of ig) might want to take this over at some point.