### PR TITLE
Added Xauth

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1369,6 +1369,9 @@ packages:
     "Patrick Redmond <plredmond@gmail.com> @plredmond":
         - GPipe-GLFW
 
+    "Spencer Janssen <spencerjanssen@gmail.com>":
+        - Xauth
+
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6


### PR DESCRIPTION
This package will need the C headers for libXau, which hopefully is not a problem.  On Debian, for example, the headers live in libxau-dev.

cc @nh2 