### PR TITLE
Add cheapskate to stackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1397,6 +1397,9 @@ packages:
         - io-streams
         - openssl-streams
         
+    "Sean Hunt <scshunt@csclub.uwaterloo.ca @scshunt":
+        - cheapskate
+
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6


### PR DESCRIPTION
Add `cheapskate`.

I did not receive a reply from the Hackage maintainer.