### PR TITLE
Added forecast-io to Stackage build references

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1396,6 +1396,9 @@ packages:
         - hashtables
         - io-streams
         - openssl-streams
+
+    "Devan Stormont <stormont@gmail.com>":
+        - forecast-io
         
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537


### PR DESCRIPTION
Desire to add the forecast-io package (currently at 0.2.0.0) to Stackage references.