### PR TITLE
language-nix: expect the test suite to succeed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1930,9 +1930,6 @@ expected-test-failures:
     # https://github.com/athanclark/pred-trie/issues/1
     - pred-trie
 
-    # https://github.com/peti/language-nix/issues/1
-    - language-nix
-
     # https://github.com/kazu-yamamoto/ghc-mod/issues/611
     - ghc-mod
 


### PR DESCRIPTION
Version 2.1 fixes the issues we've previously had. The update changes
the package's API, but that's okay because it doesn't have any users in
Stackage yet.