### PR TITLE
Add diversity and github account

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1449,8 +1449,9 @@ packages:
     "Jinjing Wang <nfjinjing@gmail.com> @nfjinjing":
         - moesocks
 
-    "Gregory W. Schwartz <gregory.schwartz@drexel.edu>":
+    "Gregory W. Schwartz <gregory.schwartz@drexel.edu> @GregorySchwartz":
         - fasta
+        - diversity
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537


### PR DESCRIPTION
Requires nightly in order to depend on the fasta package form stackage:

stack install --resolver nightly-2015-09-20