### PR TITLE
Expect spurious failures from pandoc-citeproc-0.7.3.1's test suite.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1964,6 +1964,9 @@ expected-haddock-failures:
     # Not sure why, but it's a temporary package anyway
     - Cabal-ide-backend
 
+    # https://github.com/jgm/pandoc-citeproc/issues/172
+    - pandoc-citeproc
+
 # Benchmarks which should not be built. Note that Stackage does *not* generally
 # build benchmarks. The difference here will be whether dependencies for these
 # benchmarks are included or not.


### PR DESCRIPTION
https://github.com/jgm/pandoc-citeproc/issues/172