### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1459,6 +1459,13 @@ packages:
     "Gregory W. Schwartz <gregory.schwartz@drexel.edu> @GregorySchwartz":
         - fasta
         - diversity
+    
+    "Simon Marechal <bartavelle@gmail.com> @bartavelle":
+        - compactmap
+        - stateWriter
+        - filecache
+        - pcre-utils
+        - strict-base-types
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537


### PR DESCRIPTION
Add a few packages I maintain, plus `strict-base-types` that I don't, but that is required by `pcre-utils`. What is the policy on that front ?