### PR TITLE
Enable tests for hapistrano

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1956,9 +1956,6 @@ expected-test-failures:
     # https://github.com/tweag/HaskellR/issues/208
     - H
 
-    # https://github.com/stackbuilders/hapistrano/issues/31
-    - hapistrano
-
 # Haddocks which are expected to fail. Same concept as expected test failures.
 expected-haddock-failures:
     # https://github.com/acw/bytestring-progress/issues/4


### PR DESCRIPTION
The tests for [hapistrano 0.2.1.1](http://hackage.haskell.org/package/hapistrano-0.2.1.1) should fix https://github.com/stackbuilders/hapistrano/issues/31 and https://github.com/fpco/stackage/commit/9d919c04d92662942a9bff5d8a43eae1e7993214 can be reverted.