### PR TITLE
Expect spurious failures from pandoc-citeproc-0.7.3.1's test suite some more

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1965,6 +1965,9 @@ expected-test-failures:
     # https://github.com/tweag/HaskellR/issues/208
     - H
 
+    # https://github.com/jgm/pandoc-citeproc/issues/172
+    - pandoc-citeproc
+
 # Haddocks which are expected to fail. Same concept as expected test failures.
 expected-haddock-failures:
     # https://github.com/acw/bytestring-progress/issues/4
@@ -1983,9 +1986,6 @@ expected-haddock-failures:
 
     # Not sure why, but it's a temporary package anyway
     - Cabal-ide-backend
-
-    # https://github.com/jgm/pandoc-citeproc/issues/172
-    - pandoc-citeproc
 
 # Benchmarks which should not be built. Note that Stackage does *not* generally
 # build benchmarks. The difference here will be whether dependencies for these


### PR DESCRIPTION
This patch fixes https://github.com/fpco/stackage/pull/853, which accidentally
inserted the entry for pandoc-citeproc into the "haddock" section rather than
the one for test suites failures. Sorry!