### PR TITLE
Add sbp and postgresql-schema to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1452,6 +1452,10 @@ packages:
         - nix-paths
         - streamproc
 
+    "Mark Fine <mark.fine@gmail.com> @markfine":
+        - postgresql-schema
+        - sbp
+
     "Christoph Hegemann <christoph.hegemann1337@gmail.com":
         - psc-ide
 


### PR DESCRIPTION
I'd love to get these two packages into stackage. I'm a little fuzzy if they need appropriate bounds checks to be able to come in. Please let me know how I can verify or check for that. Thanks!