### PR TITLE
Test suite in second-transfer works in the stack environment...

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1900,9 +1900,6 @@ expected-test-failures:
     # https://github.com/kazu-yamamoto/http2/issues/4
     - http2
 
-    # https://github.com/alcidesv/second-transfer/issues/1
-    - second-transfer
-
     # https://github.com/prowdsponsor/mangopay/issues/30
     - mangopay
 


### PR DESCRIPTION
…by faking OpenSSL 1.0.2 symbols when older versions of the library are used. This closes [this issue](https://github.com/alcidesv/second-transfer/issues/1#issuecomment-145190625). 