### PR TITLE
Remove version constraints on ig package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1545,9 +1545,6 @@ packages:
         # https://github.com/fpco/stackage/issues/860
         - optparse-applicative < 0.12
 
-        # https://github.com/fpco/stackage/issues/875
-        - ig < 0.6
-
         # https://github.com/fpco/stackage/issues/880
         - http-types < 0.9
 


### PR DESCRIPTION
ig-0.6 required attoparsec < 0.13, but ig-0.6.1 removes the dependency on attoparsec.  So ig-0.6.1 should build with the latest version of stackage.

This fixes #875 and was implemented in the ig repo here: https://github.com/prowdsponsor/ig/pull/21