### PR TITLE
add Win32-extras

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -571,6 +571,7 @@ packages:
 
     "Joey Hess <id@joeyh.name>":
         - git-annex < 5.20150731
+        - Win32-extras
 
     "Ketil Malde":
         - biocore
@@ -1666,6 +1667,7 @@ skipped-builds:
     - hfsevents
     - Win32
     - Win32-notify
+    - Win32-extras
 
 
 # By skipping a test suite, we do not pull in the build dependencies


### PR DESCRIPTION
This is a dependency of git-annex on Windows, and won't otherwise be included since deps are resolved for linux and not windows. Per https://github.com/commercialhaskell/stack/issues/1158

I put it under my name, although I don't maintain the package, because I can't speak for the authors of Win32-extras regarding putting it in stackage, and it's so far only included because git-annex uses it. Hopefully this is ok.