### PR TITLE
Add ‘htaglib’ package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1505,6 +1505,7 @@ packages:
 
     "Mark Karpov <markkarpov@opmbx.org> @mrkkrp":
         - megaparsec
+        - htaglib
 
     "Thomas Bereknyei <tomberek@gmail.com>":
         - multiplate


### PR DESCRIPTION
HTagLib is binding to C API of popular C++ library for reading and editing of audio meta information (i.e. tags) of many popular audio formats. There are at least two other projects doing “the same” thing, both are almost identical and very low-level.

This project provides high-level Haskellish interface (e.g. it uses applicative interface to read tags directly into your data structure, etc.). Reading and writing of meta data is performed as “atomic” operations, so it's impossible to forget to close file, etc. It's also type-safe.
