### PR TITLE
Add hsndfile package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1653,6 +1653,9 @@ packages:
     # "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":
     #    - exp-pairs
 
+    "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
+        - hsndfile
+
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537
         - zlib < 0.6


### PR DESCRIPTION
`hsndfile` is a Haskell wrapper for the `libsndfile` C library for cross-platform
soundfile I/O.

Note that this package depends on an external library. On Ubuntu, installing the package [libsndfile1-dev](http://packages.ubuntu.com/precise/libsndfile1-dev) should be sufficient.
