### PR TITLE
Add tagstream-conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1655,6 +1655,9 @@ packages:
     # https://github.com/fpco/stackage/pull/980
     # "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
     #     - hsndfile
+    
+    "yihuang <yi.codeplayer@gmail.com> @yihuang":
+        - tagstream-conduit
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/537


### PR DESCRIPTION
tagstream-conduit is a conduit library for parse html tags which tolerate bad tags as best as it can.