### PR TITLE
Place generic-deriving under a maintainer

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -332,7 +332,6 @@ packages:
         - gl
         - lens-aeson
         - zlib-lens
-        - generic-deriving
         - hyperloglog
 
     "Andrew Farmer <afarmer@ittc.ku.edu>":
@@ -1372,6 +1371,7 @@ packages:
 
     "Ryan Scott <ryan.gl.scott@gmail.com> @RyanGlScott":
         - base-orphans
+        - generic-deriving
         - invariant
         - keycode
         - text-show


### PR DESCRIPTION
I'm a maintainer of `generic-deriving`, so in case its dependencies become out of date, it should notify me. (Previously, it was listed under Edward Kmett, who uses it in his libraries but isn't a maintainer AFAIK.)