### PR TITLE
add ekg and ekg-json to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -668,6 +668,8 @@ packages:
 
     "Yann Esposito <yann.esposito@gmail.com>":
         - holy-project
+        - ekg
+        - ekg-json
 
     "Paul Rouse <pgr@doynton.org>":
         - yesod-auth-hashdb


### PR DESCRIPTION
From this discussion

https://github.com/tibbe/ekg/pull/49#issuecomment-159700862

I believe there is no problem for me to put ekg (and ekg-json) on stackage. The package compiled with the Haskell LTS 3-15 without any issue.


