### PR TITLE
Enable ‘hsndfile’ and other packages of the family

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1662,9 +1662,9 @@ packages:
     # "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":
     #    - exp-pairs
 
-    # https://github.com/fpco/stackage/pull/980
-    # "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
-    #     - hsndfile
+    "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
+        - hsndfile
+        - hsndfile-vector
 
     "yihuang <yi.codeplayer@gmail.com> @yihuang":
         - tagstream-conduit
@@ -1682,7 +1682,7 @@ packages:
 
     "Henry J. Wylde <public@hjwylde.com> @hjwylde":
         - git-fmt
-    
+
     "Will Sewell <me@willsewell.com @willsewell_>":
         - benchpress
 


### PR DESCRIPTION
New version of `c2hs` is released where the bug that prevented `hsndfile` from building is fixed according to maintainer of `c2hs`:

https://github.com/haskell/c2hs/issues/152#issuecomment-160433034

It also turns out that the package `hsndfile` itself is of little use without one of the following:

* `hsndfile-iteratee`
* `hsndfile-storablevector`
* `hsndfile-vector`

These packages provide instances of `Buffer` type class using wrappers around corresponding data types. Without one of these it's not possible to access individual audio samples.

----

That change on line 1685 is not intentional, I think Emacs got its way to eat some trailing whitespace.
