### PR TITLE
drop sbv upperbound

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1720,9 +1720,6 @@ packages:
         - postgresql-binary < 0.7.4
         - hasql < 0.14.0.2
 
-        # https://github.com/GaloisInc/cryptol/issues/275
-        - sbv < 5.0
-
         # https://github.com/fpco/stackage/issues/856
         - syb < 0.6
 


### PR DESCRIPTION
Cryptol works with latest SBV release (the ticket referenced is stale.)