### PR TITLE
Re-enable Agda

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1434,9 +1434,7 @@ packages:
         - ipython-kernel
 
     "Andrés Sicard-Ramírez <asr@eafit.edu.co> @asr":
-        # Temporarily removed due to upper bound on haskell-src-exts
-        # - Agda
-        []
+        - Agda
 
     "James Cook <mokus@deepbondi.net> @mokus0":
         - dependent-sum


### PR DESCRIPTION
Agda supports haskell-src-exts 1.17.* (#981) and zlib 0.6.* (#537) now.