### PR TITLE
Re-enable hakyll with fixed http-types

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -180,8 +180,7 @@ packages:
     "Jasper Van der Jeugt":
         - blaze-html
         - blaze-markup
-        # http-types < 0.9
-        # - hakyll
+        - hakyll
         - stylish-haskell
         - psqueues
         - websockets
@@ -430,8 +429,7 @@ packages:
         - dixi
         - latex-formulae-image
         - latex-formulae-pandoc
-        # http-types < 0.9
-        # - latex-formulae-hakyll
+        - latex-formulae-hakyll
         # Temporarily removed due to upper bound on haskell-src-exts in Agda
         # - agda-snippets
         # - agda-snippets-hakyll


### PR DESCRIPTION
`http-types` dependency is fixed in `hakyll-4.7.5.0`.