### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1680,8 +1680,8 @@ packages:
         - inline-c-cpp
         - ekg
 
-    # "Emin Karayel <me@eminkarayel.de>":
-    #     - sync-mht
+    "Emin Karayel <me@eminkarayel.de>":
+        - sync-mht
 
     "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":
         - ttrie
@@ -1963,7 +1963,6 @@ skipped-tests:
     - parsec
     - rank1dynamic
     - shelltestrunner
-    - sync-mht
     - terminal-progress-bar
     - threads
     - yesod-static-angular


### PR DESCRIPTION
Reenabled sync-mht (after checking that it builds without HUnit < 1.3)