### PR TITLE
Add http-streams package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1523,6 +1523,10 @@ packages:
         - io-streams
         - openssl-streams
 
+    "Andrew Cowie <andrew@operationaldynamics.com> @afcowie":
+        - http-common
+        - http-streams
+
     "Devan Stormont <stormont@gmail.com>":
         - forecast-io
 


### PR DESCRIPTION
Long overdue, but now that **io-streams** is in, we can add the HTTP client library built on it. Also adds **http-common** package.

AfC