### PR TITLE
Add ‘LibZip’, bindings to ‘libzip’

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1864,6 +1864,10 @@ packages:
         - simple-session
         - simple-postgresql-orm
 
+    "Sergey Astanin <s.astanin@gmail.com> @astanin":
+        - bindings-libzip < 0.11
+        - LibZip < 0.11
+
     # If you stop mainaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     "Abandoned packages":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -66,6 +66,7 @@ apt-get install -y \
     libxml2-dev \
     libxss-dev \
     libyaml-dev \
+    libzip-dev \
     libzmq3-dev \
     llvm \
     m4 \


### PR DESCRIPTION
I tried to contact the author, but it takes too long for him to answer, so I decided to add this myself. This is binding to `libzip`, C library to work with zip archives. Nice interface, better than all those bindings where you have to work with pointers in Haskell code :-) It should be more efficient than `zip-archive` that reads in memory all archive contents on every action.