### PR TITLE
Add the Stack Builders packages (and dotenv)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1385,10 +1385,11 @@ packages:
         - transformers-lift
         - ether
 
-    "Juan Pedro Villa Isaza jvilla@stackbuilders.com @jpvillaisaza":
+    "Stack Builders stackage@stackbuilders.com @stackbuilders":
         - hapistrano
         - inflections
         - twitter-feed
+        - dotenv
 
     "Sergey Alirzaev <zl29ah@gmail.com>":
         - monad-peel
@@ -2499,6 +2500,12 @@ github-users:
         - stepcut
     clckwrks:
         - stepcut
+    stackbuilders:
+        - sestrella
+        - CristhianMotoche
+        - jsl
+        - jpvillaisaza
+        - jsantos17
 
 # end of github-users
 


### PR DESCRIPTION
Can we change the maintainer name and details to Stack Builders for existing packages in Stackage like this? We're also adding a new one that we're maintaining. Thanks!