### PR TITLE
Add `simple` and `postgresql-orm`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1844,6 +1844,13 @@ packages:
     "Jakub Waszczuk <waszczuk.kuba@gmail.com> @kawu":
         - dawg-ord
 
+    "Amit Levy <amit@amitlevy.com> @alevy":
+        - postgresql-orm
+        - simple
+        - simple-templates
+        - simple-session
+        - simple-postgresql-orm
+
     # If you stop mainaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     "Abandoned packages":


### PR DESCRIPTION
Add the _Simple_ web framework packages (templates, orm and sessions) as well as `postgresql-orm`, a `postgresql-simple`-based ORM