### PR TITLE
Update hdevtools

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -803,6 +803,8 @@ packages:
 
     "Arthur Fayzrakhmanov <heraldhoi@gmail.com>":
         - sodium
+        
+    "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
         - hdevtools
 
     "Andrey Chudnov <oss@chudnov.com>":


### PR DESCRIPTION
@geraldus I took over maintenance of hdevtools some weeks ago and pushed a new version to Hackage today. But I am not quite sure if this file has to be changed in order to have hdevtools in the stackage LTS release?