### PR TITLE
Remove dawg-ord < 0.5 constraint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1905,9 +1905,6 @@ packages:
         # https://github.com/fpco/stackage/issues/1124
         - brick < 0.4
 
-        # https://github.com/kawu/dawg-ord/issues/2
-        - dawg-ord < 0.5
-
 # end of packages
 
 


### PR DESCRIPTION
Test suite build failure (kawu/dawg-ord#2) should be now fixed.