### PR TITLE
Add ‘path-io’ package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1622,6 +1622,7 @@ packages:
         - megaparsec
         - htaglib
         - slug
+        - path-io
 
     "Thomas Bereknyei <tomberek@gmail.com>":
         - multiplate


### PR DESCRIPTION
This package provides well-typed interface to `directory` for users of Chris Done's `path`. It also implements some missing stuff like recursive scanning and copying of directories.
