### PR TITLE
Add ‘hspec-megaparsec’ package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1639,6 +1639,7 @@ packages:
         - htaglib
         - slug
         - path-io
+        - hspec-megaparsec
 
     "Thomas Bereknyei <tomberek@gmail.com>":
         - multiplate


### PR DESCRIPTION
Inspired by `hspec-attoparsec`, these utilities should reduce boilerplate for those who need to test Megaparsec parsers with Hspec.