### PR TITLE
Reintroduce HaskellR suite of packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1314,8 +1314,9 @@ packages:
         - nationstates
 
     "Mathieu Boespflug <mboes@tweag.net> @mboes":
-        # profunctors https://github.com/fpco/stackage/issues/590
-        # netwire
+        - H
+        - ihaskell-inline-r
+        - inline-r
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":
@@ -2109,6 +2110,9 @@ skipped-tests:
     # https://github.com/ku-fpg/blank-canvas/issues/73
     # Never finishes
     - blank-canvas
+
+    # Requires tasty-expected-failure
+    - inline-r
 
 # end of skipped-tests
 


### PR DESCRIPTION
inline-r test suite disabled for now because it depends on
tasty-expected-failure, a package not in Stackage.