### PR TITLE
Reenable inline-r tests.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2111,9 +2111,6 @@ skipped-tests:
     # Never finishes
     - blank-canvas
 
-    # Requires tasty-expected-failure
-    - inline-r
-
 # end of skipped-tests
 
 # Tests which we should build and run, but which are expected to fail. We


### PR DESCRIPTION
Since tasty-expected-failure is in fact in Stackage now.