### PR TITLE
Re-adds cloud-haskell packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1672,15 +1672,14 @@ packages:
 
     "Facundo Domínguez <facundo.dominguez@tweag.io> @facundominguez":
         - distributed-process
-        # Removed due to inactivity https://github.com/fpco/stackage/issues/768
-        # - distributed-process-async
-        # - distributed-process-client-server
-        # - distributed-process-execution
-        # - distributed-process-extras
-        # - distributed-process-registry
-        # - distributed-process-simplelocalnet
-        # - distributed-process-supervisor
-        # - distributed-process-task
+        - distributed-process-async
+        - distributed-process-client-server
+        - distributed-process-execution
+        - distributed-process-extras
+        - distributed-process-registry
+        - distributed-process-simplelocalnet
+        - distributed-process-supervisor
+        - distributed-process-task
         - distributed-static
         - network-transport
         - network-transport-tcp


### PR DESCRIPTION
The upper bounds of the HUnit dependency have been increased and minor releases have been uploaded to hackage. First reported here: https://github.com/fpco/stackage/issues/768