### PR TITLE
Add me to namemaps, my newer packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1454,9 +1454,12 @@ packages:
 
     "Ryan Scott <ryan.gl.scott@gmail.com> @RyanGlScott":
         - base-orphans
+        - deriving-compat
         - generic-deriving
         - invariant
         - keycode
+        - lift-generics
+        - mtl-compat
         - text-show
 
     "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
@@ -2583,6 +2586,10 @@ github-users:
     scotty-web:
         - RyanGlScott
         - xich
+    ku-fpg:
+        - RyanGlScott
+    haskell-compat:
+        - RyanGlScott
 
 # end of github-users
 


### PR DESCRIPTION
This accomplishes two things:

* Adds me as the maintainer of `deriving-compat`, `lift-generics`, and `mtl-compat`
* Adds my username to the namemap for @ku-fpg and @haskell-compat (the former would have helped fix #1189 earlier)