### PR TITLE
Remove transformers-compat upper bound.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1945,10 +1945,6 @@ packages:
         # https://github.com/fpco/stackage/issues/1131
         - unordered-containers < 0.2.6
 
-        # https://github.com/fpco/stackage/issues/1146
-        - transformers-compat < 0.5
-        - bifunctors < 5.2.1
-
         # https://github.com/fpco/stackage/issues/1147
         - comonad < 4.3
         - pointed < 5
@@ -1958,9 +1954,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/1155
         - aeson < 0.10
-
-        # https://github.com/fpco/stackage/issues/1207
-        - text-show < 3
 
 # end of packages
 


### PR DESCRIPTION
This should work, but my local stackage-curator doesn't pick up the new versions of Mario's packages for unknown reason. Let's see if travis makes it work.
