### PR TITLE
Use the Gold linker rather than the default ld.bfd.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1324,7 +1324,7 @@ packages:
 
     "Mathieu Boespflug <mboes@tweag.net> @mboes":
         - H
-        # - ihaskell-inline-r
+        - ihaskell-inline-r
         - inline-r
         - th-lift
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -114,3 +114,9 @@ mkdir -p /usr/lib/x86_64-linux-gnu/
 ln -sfv /usr/lib/libnettle.so.6.1 /usr/lib/x86_64-linux-gnu/libnettle.so.6
 )
 rm -rf /tmp/nettle-build
+
+# Buggy versions of ld.bfd fail to link some Haskell packages:
+# https://sourceware.org/bugzilla/show_bug.cgi?id=17689. Gold is
+# faster anyways and uses less RAM.
+update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
+update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10


### PR DESCRIPTION
This works around bug
https://sourceware.org/bugzilla/show_bug.cgi?id=17689, which causes
ld.bfd to fail to successfully link some Haskell packages.

In particular, switching the default here makes ihaskell-inline-r
compile successfully. On some versions of Ubuntu it otherwise fails at
the link stage. See #1186.