### PR TITLE
Add doctest-discover under @karun012

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1973,6 +1973,9 @@ packages:
         # https://github.com/fpco/stackage/issues/1215
         - argon < 0.4.1.0
 
+    "Karun Ramakrishnan karun012@gmail.com @karun012":
+        - doctest-discover
+
 # end of packages
 
 


### PR DESCRIPTION
This change adds the [`doctest-discover`](https://github.com/karun012/doctest-discover) package with the permission of the package's maintainer.
