### PR TITLE
Add ekg-statsd

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1174,6 +1174,7 @@ packages:
     "Taylor Fausak <taylor@fausak.me> @tfausak":
         - flow
         - octane
+        - ekg-statsd
 
     "Marios Titas <redneb@gmx.com> @redneb":
         - btrfs


### PR DESCRIPTION
This adds http://hackage.haskell.org/package/ekg-statsd. I am not the maintainer. Other ekg packages are already in Stackage, but none of them were added by @tibbe.