### PR TITLE
Add `zip` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1680,6 +1680,7 @@ packages:
         - path-io
         - hspec-megaparsec
         - plan-b
+        - zip
 
     "Thomas Bereknyei <tomberek@gmail.com>":
         - multiplate


### PR DESCRIPTION
This is a new package to work with zip archives. It's fast (thanks to conduits), feature-rich, and implements more features from .ZIP specification than any anything on Hackage at the moment.

Note that this requires `path-io >= 1.0.1`, see #1238.
