### PR TITLE
Enable wai-middleware-throttle in build-constraints

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2486,9 +2486,6 @@ expected-test-failures:
     # Sent e-mail to maintainer
     - ListLike
 
-    # https://github.com/creichert/wai-middleware-throttle/issues/4
-    - wai-middleware-throttle
-
     # https://bitbucket.org/ssaasen/haskell-jwt/issues/18/test-suite-build-failure-in-stackage
     - jwt
 


### PR DESCRIPTION
The test-suite issue has been fixed upstream, thanks @bergmark