### PR TITLE
Revert "Disable reedsolomon per #1279"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2012,9 +2012,8 @@ packages:
     "Lennart Kolmodin <kolmodin@gmail.com> @kolmodin":
         - binary-bits
 
-    # https://github.com/fpco/stackage/issues/1279
-    # "Nicolas Trangez ikke@nicolast.be @NicolasT":
-    #     - reedsolomon
+    "Nicolas Trangez ikke@nicolast.be @NicolasT":
+        - reedsolomon
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
@@ -2141,6 +2140,9 @@ package-flags:
 
     fay:
         test: true
+
+    reedsolomon:
+        llvm: false
 
 # end of package-flags
 


### PR DESCRIPTION
Re-enable the `reedsolomon` package, but disable the `llvm` Cabal flag:
the Stackage build servers run a version of LLVM that's incompatible
with the GHC version being used, causing the build to fail when the
`llvm` flag (which passes `-fllvm` to GHC) is enabled.

This reverts commit 10a218a8436290ca4e962bcea5d6e18e4e291917.

Conflicts:
	build-constraints.yaml

Fixes: fpco/stackage#1279
See: https://github.com/fpco/stackage/issues/1279