### PR TITLE
Add additional amazonka libraries

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1048,12 +1048,14 @@ packages:
         - amazonka-test
         - amazonka-apigateway
         - amazonka-autoscaling
+        - amazonka-certificatemanager
         - amazonka-cloudformation
         - amazonka-cloudfront
         - amazonka-cloudhsm
         - amazonka-cloudsearch-domains
         - amazonka-cloudsearch
         - amazonka-cloudtrail
+        - amazonka-cloudwatch-events
         - amazonka-cloudwatch-logs
         - amazonka-cloudwatch
         - amazonka-codecommit
@@ -1065,10 +1067,12 @@ packages:
         - amazonka-datapipeline
         - amazonka-devicefarm
         - amazonka-directconnect
+        - amazonka-dms
         - amazonka-ds
         - amazonka-dynamodb-streams
         - amazonka-dynamodb
         - amazonka-ec2
+        - amazonka-ecr
         - amazonka-ecs
         - amazonka-efs
         - amazonka-elasticache
@@ -1077,6 +1081,7 @@ packages:
         - amazonka-elastictranscoder
         - amazonka-elb
         - amazonka-emr
+        - amazonka-gamelift
         - amazonka-glacier
         - amazonka-iam
         - amazonka-importexport
@@ -1088,6 +1093,7 @@ packages:
         - amazonka-kms
         - amazonka-lambda
         - amazonka-marketplace-analytics
+        - amazonka-marketplace-metering
         - amazonka-ml
         - amazonka-opsworks
         - amazonka-rds


### PR DESCRIPTION
Adds the following libraries:

- [amazonka-certificatemanager](http://hackage.haskell.org/package/amazonka-certificatemanager): Certificate Manager. ([details](https://aws.amazon.com/documentation/acm/))
- [amazonka-dms](http://hackage.haskell.org/package/amazonka-dms): Database Migration Service. ([details](https://aws.amazon.com/documentation/dms/))
- [amazonka-ecr](http://hackage.haskell.org/package/amazonka-ecr): Elastic Container Registry. ([details](https://aws.amazon.com/documentation/ecr/))
- [amazonka-cloudwatch-events](http://hackage.haskell.org/package/amazonka-cloudwatch-events): CloudWatch Events. ([details](https://aws.amazon.com/cloudwatch/))
- [amazonka-gamelift](http://hackage.haskell.org/package/amazonka-gamelift): GameLift. ([details](https://aws.amazon.com/documentation/gamelift/))
- [amazonka-marketplace-metering](http://hackage.haskell.org/package/amazonka-marketplace-metering) Marketplace Metering Service. ([details](https://aws.amazon.com/documentation/marketplace/))
