### PR TITLE
Add ghc-imported-from to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2068,6 +2068,9 @@ packages:
         - unification-fd
         - unix-bytestring
 
+    "Carlo Hamalainen <carlo@carlo-hamalainen.net> @carlohamalainen":
+        - ghc-imported-from
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
I've updated my package ghc-imported-from to build with Stack and now I'd like for users to be able to install it from stack.

https://hackage.haskell.org/package/ghc-imported-from