### PR TITLE
whitelist giphy-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1936,9 +1936,7 @@ packages:
         - stack-run-auto
 
     "Pascal Hartig <phartig@rdrei.net> @passy":
-        # https://github.com/fpco/stackage/pull/1316
-        #- giphy-api
-        []
+        - giphy-api
 
     "rightfold <rightfold@gmail.com> @rightfold":
         - open-browser


### PR DESCRIPTION
This reverts d2e91d713a059880dfe70e8de26ebebd898a31f9, see #1316. The test fixtures that caused the failures are now included in the sdist.