### PR TITLE
Support doctest 0.11 in wuss

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2395,7 +2395,6 @@ skipped-tests:
     - linear
     - patches-vector
     - semigroupoids
-    - wuss
 
 # end of skipped-tests
 


### PR DESCRIPTION
As reported in https://github.com/fpco/stackage/issues/1328. Fixed by https://github.com/tfausak/wuss/commit/b7a3484d7c53817528cb709e9992efc95ea9e9c4. Released in https://hackage.haskell.org/package/wuss-1.0.4.