### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1694,9 +1694,6 @@ packages:
         # https://github.com/fpco/stackage/issues/873
         # - sbp
 
-    "Christoph Hegemann <christoph.hegemann1337@gmail.com":
-        - psc-ide
-
     "Jinjing Wang <nfjinjing@gmail.com> @nfjinjing":
         - moesocks
 


### PR DESCRIPTION
psc-ide has been deprecated and shouldn't be installed anymore