### PR TITLE
Add flag for pinchot

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2307,6 +2307,12 @@ package-flags:
     # https://github.com/ghcjs/jsaddle/issues/9
     jsaddle:
         gtk3: true
+
+    # Only necessary for template-haskell < 2.11, so please
+    # remove this when moving up to GHC 8.0
+    pinchot:
+        oldTemplateHaskell: true
+
 # end of package-flags
 
 


### PR DESCRIPTION
This flag is needed only when building for GHC < 8.0.