### PR TITLE
Add github-release

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1213,8 +1213,10 @@ packages:
         - bento
         - ekg-statsd # Maintained by @tibbe.
         - flow
+        - github-release
         - lackey
         - octane
+        - optparse-generic # Maintained by @Gabriel439.
         - ratel
         - ratel-wai
         - strive


### PR DESCRIPTION
https://github.com/tfausak/github-release

This also adds optparse-generic, which is one of github-release's dependencies. That library is maintained by @Gabriel439.