### PR TITLE
add gi-gtk under juhp

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -910,6 +910,7 @@ packages:
         - cabal-sort
         - ghcjs-codemirror
         - ghcjs-dom
+        - gi-gtk
         - gtksourceview3
         - idris
         - jsaddle


### PR DESCRIPTION
cc @haskell-gi

This will be needed by the next leksah release.
I suggested this to @garetxe and probably he can take over the haskell-gi stack later in Stackage.