### PR TITLE
move to Ubuntu 16.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 ENV HOME /home/stackage
 ENV LANG en_US.UTF-8

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2359,10 +2359,7 @@ skipped-builds:
     - Win32-notify
     - Win32-extras
 
-    # The Docker image needs libsystemd-dev from Ubuntu 15.04+ for this.
-    # See: https://github.com/fpco/stackage/issues/696
-    - libsystemd-journal
-
+# end of skipped-builds
 
 
 # By skipping a test suite, we do not pull in the build dependencies

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -26,7 +26,7 @@ add-apt-repository -y ppa:openstack-ubuntu-testing/icehouse
 
 # Get Stack
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
-echo 'deb http://download.fpcomplete.com/ubuntu trusty main'|sudo tee /etc/apt/sources.list.d/fpco.list
+echo 'deb http://download.fpcomplete.com/ubuntu xenial main'|sudo tee /etc/apt/sources.list.d/fpco.list
 
 apt-get update
 apt-get install -y \
@@ -81,6 +81,7 @@ apt-get install -y \
     libsndfile1-dev \
     libsqlite3-dev \
     libssl-dev \
+    libsystemd-dev \
     libtagc0-dev \
     libtre-dev \
     libudev-dev \


### PR DESCRIPTION
This should allow libsystemd-journal (#696) and also gi-gtk to build (#1434, #1435)

Untested but hopefully this should work.