### PR TITLE
Re-enable stratosphere

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2168,9 +2168,7 @@ packages:
         - protobuf-simple
 
     "David Reaver <johndreaver@gmail.com> @jdreaver":
-        []
-        # https://github.com/fpco/stackage/pull/1445
-        #- stratosphere
+        - stratosphere
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
As was pointed out @juhp in #1445, the tests for `stratosphere` were broken because of a development directory that doesn't exist in the final source distribution. I've fixed that in [this commit](https://github.com/frontrowed/stratosphere/commit/2d7db034b6182771f30aef57ce6f90fbaba530b9) and also uploaded a new version (0.1.1) to [hackage](https://hackage.haskell.org/package/stratosphere-0.1.1).

Hopefully there aren't any more errors once we are merged into master!