### PR TITLE
Restore cmark benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2162,7 +2162,7 @@ packages:
 
     "Cies Breijs <cies@kde.nl> @cies":
         - htoml
-    
+
     "Martijn Rijkeboer <mrr@sru-systems.com> @mrijkeboer":
         - protobuf-simple
 
@@ -2887,9 +2887,6 @@ skipped-benchmarks:
     - case-insensitive
     - postgresql-binary
     - scientific
-
-    # Pulls in discount which depends on extra C libraries
-    - cmark
 
     # Old criterion
     - acid-state

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -68,6 +68,7 @@ apt-get install -y \
     libmagic-dev \
     libmagickcore-dev \
     libmagickwand-dev \
+    libmarkdown2-dev \
     libmysqlclient-dev \
     libncurses-dev \
     libnotify-dev \


### PR DESCRIPTION
It seems that `cmark`'s benchmarks were disabled rather prematurely, since all it takes to install its dependency `discount` is to just install `libmarkdown2-dev` on Ubuntu.

See also https://github.com/iu-parfunc/sc-haskell/issues/7