### PR TITLE
Build some benchmarks which have been fixed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2816,8 +2816,6 @@ expected-benchmark-failures:
     - cipher-aes128
     - cryptohash
     - dbus
-    - effect-handlers
-    - fast-builder
     - gitson
     - hashable
     - http-link-header
@@ -2827,19 +2825,19 @@ expected-benchmark-failures:
     - mongoDB
     - mutable-containers
     - picoparsec
-    - pipes
-    - psqueues
     - rethinkdb
     - stateWriter
     - streaming-commons
     - thyme
-    - vector-binary-instances
     - vinyl
     - warp
     - web-routing
     - xmlgen
     - yesod-core
     - yi-rope
+
+    # https://github.com/commercialhaskell/stack/issues/2153
+    - vector-binary-instances
 
 # end of expected-benchmark-failures
 


### PR DESCRIPTION
Some benchmark suites have been fixed and uploaded to Hackage since they were originally placed in `expected-benchmark-failures`, so this PR takes them out:

* [`effect-handlers`](https://github.com/edofic/effect-handlers/issues/17)
* [`fast-builder`](https://github.com/takano-akio/fast-builder/issues/3)
* [`pipes`](https://github.com/Gabriel439/Haskell-Pipes-Library/issues/166)
* [`psqueues`](https://github.com/bttr/psqueues/issues/17)

I also added a link to https://github.com/commercialhaskell/stack/issues/2153, which notes why `vector-binary-instances` fails to build.

See also https://github.com/iu-parfunc/sc-haskell/issues/7, https://github.com/fpco/stackage/issues/1372#issuecomment-213020065