### PR TITLE
build-constraints.yaml: expect vty's tests to fail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2492,6 +2492,9 @@ skipped-tests:
 # should not fail a build based on a test failure for one of these packages.
 expected-test-failures:
 
+    # https://github.com/fpco/stackage/issues/1453
+    - vty
+
     # https://github.com/bos/statistics/issues/42
     - statistics
 


### PR DESCRIPTION
Re-created PR https://github.com/fpco/stackage/pull/1455, which I accidentally closed somehow. This patch addresses https://github.com/fpco/stackage/issues/1453.