### PR TITLE
carray benchmarks fixed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2850,7 +2850,6 @@ expected-benchmark-failures:
     - attoparsec
     - bzlib-conduit
     - cacophony
-    - carray
     - cipher-aes128
     - cryptohash
     - dbus


### PR DESCRIPTION
in http://hdiff.luite.com/cgit/carray/diff?id=0.1.6.4&id2=0.1.6.3

btw. should stackage build notice if tests/benchmarks are expected to fail, but they doesn't. Maybe a new section for non-robust tests / occacionally failing test-suties? (I also thought about separating non-compiling and non-passing tests, dunno if this is too granular division though)