### PR TITLE
Bring back directory-tree.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2212,6 +2212,9 @@ packages:
         - gi-pango == 1.0.3
         - haskell-gi
 
+    "Brandon Simmons <brandon.m.simmons@gmail.com>":
+        - directory-tree
+
     "Ian Grant Jeffries <ian@housejeffries.com> @seagreen":
         - hjsonpointer
         - hjsonschema
@@ -2582,6 +2585,9 @@ expected-test-failures:
     # Seems to depend on mtl being installed in user package database, which
     # isn't always the case (e.g., build server)
     - happy
+
+    # https://github.com/jberryman/directory-tree/issues/4
+    - directory-tree
 
     # https://github.com/ndmitchell/hoogle/issues/101
     - hoogle


### PR DESCRIPTION
I think `directory-tree` got removed during the GHC 8 work.  Seems to work as well as it did on 7.10, though.