### PR TITLE
Add back airship for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1821,8 +1821,7 @@ packages:
     "Tim McGilchrist <timmcgil@gmail.com>  @tmcgilchrist":
         []
         # GHC 8 - riak
-        # https://github.com/helium/airship/issues/101
-        # GHC 8 - airship
+        - airship
 
     "Yuras Shumovich <shumovichy@gmail.com> @Yuras":
         - pdf-toolbox-core


### PR DESCRIPTION
Removed unnecessary ImpredicativeTypes and now compiles under GHC 8.