### PR TITLE
GHC 8.0: Add back wai-middleware-static

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -64,7 +64,7 @@ packages:
         # GHC 8 - binary-conduit
         # GHC 8 - lzma-conduit
         # GHC 8 - mutable-containers
-        # GHC 8 - hpc-coveralls
+        - hpc-coveralls
         - monad-unlift
         # GHC 8 - monad-unlift-ref
         - yaml
@@ -320,7 +320,7 @@ packages:
 
     "Andrew Farmer <afarmer@ittc.ku.edu>":
         - scotty
-        # GHC 8 - wai-middleware-static
+        - wai-middleware-static
 
     "Simon Hengel <sol@typeful.net>":
         - hspec
@@ -2079,7 +2079,7 @@ packages:
         - rotating-log
         - ua-parser
         - hs-GeoIP
-        # GHC 8 - retry
+        - retry
         # GHC 8 - katip
         # GHC 8 - katip-elasticsearch
 


### PR DESCRIPTION
`wai-middleware-static` (as well as its dependency, `hpc-coveralls`) [were blocked](https://github.com/scotty-web/wai-middleware-static/issues/14) since a common dependency (`retry`) wouldn't build on GHC 8.0. That has been [fixed](https://github.com/Soostone/retry/issues/43) now, so this PR adds back `retry`, `hpc-coveralls`, and `wai-middleware-static`.