### PR TITLE
phantom-state should work with GHC-8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -442,7 +442,7 @@ packages:
         - include-file
         # GHC 8 - matrix
         - pcre-light
-        # GHC 8 - phantom-state
+        - phantom-state
         - post-mess-age
         - sorted-list
 


### PR DESCRIPTION
Compatible from version 0.2.1.0.