### PR TITLE
GHC 8: hdocs, hformat, hsdev, simple-log, text-region

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -847,12 +847,11 @@ packages:
         - servant-cassava
 
     "Alexandr Ruchkin voidex@live.com @mvoidex":
-        []
-        # GHC 8 - hdocs
-        # GHC 8 - hformat
-        # GHC 8 - hsdev
-        # GHC 8 - simple-log
-        # GHC 8 - text-region
+        - hdocs
+        - hformat
+        - hsdev
+        - simple-log
+        - text-region
 
     "Aleksey Kliger aleksey@lambdageek.org @lambdageek":
         - unbound-generics
@@ -2748,9 +2747,6 @@ expected-test-failures:
     - cabal-helper
     - graphviz
     - zip
-
-    # Problem with v0.1.6.0: https://github.com/fpco/stackage/issues/1206
-    - hsdev
 
     # https://github.com/elaye/turtle-options/issues/3
     - turtle-options


### PR DESCRIPTION
hsdev also passes test

I had to add `SafeSemaphore` as `extra-deps`, but as I understand there's no need for adding `SafeSemaphore` in `build-constraints.yaml`