### PR TITLE
jmacro patched for ghc 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1124,9 +1124,8 @@ packages:
         - cabal-file-th
 
     "Gershom Bazerman <gershomb@gmail.com> @gbaz":
-        # http://hub.darcs.net/gershomb/jmacro/issue/3
-        # GHC 8 - jmacro
-        # GHC 8 - jmacro-rpc
+        - jmacro
+        - jmacro-rpc
         # GHC 8 - jmacro-rpc-happstack
         # GHC 8 - jmacro-rpc-snap
         - mbox


### PR DESCRIPTION
jmacro-rpc now unblocked too. -happstack, -snap blocked on those two respectively, cubicspline blocked on hmatrix.