### PR TITLE
Pinchot is GHC 8 compatible (retry)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -118,8 +118,7 @@ packages:
         - cartel
         - Earley
         - ofx
-        # https://github.com/fpco/stackage/pull/1485
-        # GHC 8 - pinchot
+        - pinchot
         # GHC 8 - validation
 
     "Neil Mitchell":


### PR DESCRIPTION
I uploaded a new version 0.18.0.2 which should fix the problem noted
in pull request #1485.