### PR TITLE
Re-enable yesod-auth-hashdb for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -690,8 +690,7 @@ packages:
         # GHC 8 - ekg-json
 
     "Paul Rouse <pgr@doynton.org>":
-        []
-        # GHC 8 - yesod-auth-hashdb
+        - yesod-auth-hashdb
 
     "Toralf Wittner <tw@dtex.org> @twittner":
         - bytestring-conversion


### PR DESCRIPTION
Version 1.5.1.1, just released, no longer uses ClassyPrelude in the tests, and it now builds and tests successfully against nightly-2016-05-30