### PR TITLE
Add back webdriver

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1842,8 +1842,7 @@ packages:
         - blake2
 
     "Adam Curtis <kallisti.dev@gmail.com> @kallisti-dev":
-        []
-        # GHC 8 - webdriver
+        - webdriver
 
     "Luke Iannini <lukexi@me.com> @lukexi":
         []


### PR DESCRIPTION
The recently released webdriver-0.8.3 compiles fine on snapshot nightly-2016-05-30.