### PR TITLE
Re-add servant-swagger (GHC 8)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1758,7 +1758,7 @@ packages:
         # https://github.com/fpco/stackage/issues/1290
         #- smsaero
         - swagger2
-        # GHC 8 - servant-swagger
+        - servant-swagger
 
     "Jared Tobin <jared@jtobin.ca> @jtobin":
         - mwc-probability


### PR DESCRIPTION
Release 1.1 is now compatible with GHC 8