### PR TITLE
GHC 8: binary-list, HaTeX

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -432,7 +432,6 @@ packages:
         - bimap-server
         - binary-list
         - byteset
-        - Clipboard
         - grouped-list
         # needs hint to work with GHC 8: - haskintex
         - HaTeX

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -432,6 +432,7 @@ packages:
         - bimap-server
         - binary-list
         - byteset
+        - Clipboard
         - grouped-list
         # needs hint to work with GHC 8: - haskintex
         - HaTeX

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -430,11 +430,11 @@ packages:
 
     "Daniel Díaz dhelta.diaz@gmail.com @Daniel-Diaz":
         - bimap-server
-        # GHC 8 - binary-list
+        - binary-list
         - byteset
         - grouped-list
-        # GHC 8 - haskintex
-        # GHC 8 - HaTeX
+        - haskintex
+        - HaTeX
         # fails see #885
         #- hatex-guide
         - include-file

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -433,7 +433,7 @@ packages:
         - binary-list
         - byteset
         - grouped-list
-        - haskintex
+        # needs hint to work with GHC 8: - haskintex
         - HaTeX
         # fails see #885
         #- hatex-guide


### PR DESCRIPTION
I could not add `haskintex` back, since it depends on `hint`, but `hint` is not compatible with GHC 8 yet.