### PR TITLE
Add Clipboard package to Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -432,6 +432,7 @@ packages:
         - bimap-server
         - binary-list
         - byteset
+        - Clipboard
         - grouped-list
         # needs hint to work with GHC 8: - haskintex
         - HaTeX


### PR DESCRIPTION
I wanted to add this package in a separate PR. This is because, in the Linux version, `Clipboard` depends on [`X11`](http://hackage.haskell.org/package/X11). Therefore, it won't build unless the package `libxrandr-dev` is installed on the system.