### PR TITLE
phantom-state is not expected to fail (Fix #1539)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2857,9 +2857,6 @@ expected-benchmark-failures:
 
     # GHC 8
     - cassava
-
-    # https://github.com/fpco/stackage/issues/1539
-    - phantom-state
 # end of expected-benchmark-failures
 
 


### PR DESCRIPTION
Since version 0.2.1.2