### PR TITLE
Enable octane

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1192,7 +1192,7 @@ packages:
         - flow
         # GHC 8 - github-release
         - lackey
-        # GHC 8 - octane
+        - octane
         # https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/issues/23
         # GHC 8 - optparse-generic # Maintained by @Gabriel439.
         # https://github.com/tfausak/ratel/issues/1


### PR DESCRIPTION
It now builds with both lts-6.1 and nightly-2016-05-30.