### PR TITLE
Add back machines

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -277,7 +277,7 @@ packages:
         - linear
         # GHC 8 - linear-accelerate
         # GHC 8 - log-domain
-        # BLOCKED distributive 0.5 - machines
+        - machines
         - monadic-arrays
         - monad-products
         - monad-products
@@ -2385,7 +2385,6 @@ skipped-tests:
     - bound
     - heaps
     - hyphenation
-    # BLOCKED distributive 0.5 - machines
 
     # https://github.com/kaizhang/clustering/issues/2
     - clustering
@@ -2913,7 +2912,6 @@ expected-haddock-failures:
 # build benchmarks. The difference here will be whether dependencies for these
 # benchmarks are included or not.
 skipped-benchmarks:
-    - machines
     - criterion-plus
     - graphviz
     - lifted-base


### PR DESCRIPTION
[`machines-0.6.1`](http://hackage.haskell.org/package/machines-0.6.1) has been released, which has GHC 8 compatibility and working tests/benchmarks.