### PR TITLE
Add back benchmarks which now work

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2828,7 +2828,6 @@ expected-benchmark-failures:
     - Frames
     - attoparsec
     - bzlib-conduit
-    - cacophony
     - cipher-aes128
     - cryptohash
     - dbus
@@ -2839,20 +2838,18 @@ expected-benchmark-failures:
     - lens
     - lucid
     - mongoDB
-    - mutable-containers
     - picoparsec
     - rethinkdb
     - stateWriter
-    - streaming-commons
     - thyme
     - vinyl
     - warp
     - web-routing
     - xmlgen
-    - yesod-core
     - yi-rope
 
     # https://github.com/commercialhaskell/stack/issues/2153
+    - scientific
     - vector-binary-instances
 
     # GHC 8
@@ -2914,11 +2911,8 @@ expected-haddock-failures:
 # benchmarks are included or not.
 skipped-benchmarks:
     - criterion-plus
-    - graphviz
     - lifted-base
-    - pandoc
     - stm-containers
-    - uuid
 
     # pulls in criterion-plus, which has restrictive upper bounds
     - cases
@@ -2938,10 +2932,6 @@ skipped-benchmarks:
     # https://github.com/fpco/stackage/issues/494
     - case-insensitive
     - postgresql-binary
-    - scientific
-
-    # Old criterion
-    - acid-state
 
     # https://github.com/kaizhang/clustering/issues/2
     - clustering


### PR DESCRIPTION
Several benchmarks whose benchmarks were blocked from Stackage have since been fixed. I've personally verified that all of these packages' benchmarks compile with the latest nightly:

* `acid-state`
* `cacophony`
* `graphviz`
* `mutable-containers`
* `pandoc`
* `streaming-commons`
* `uuid`
* `yesod-core`

I also moved `scientific` under https://github.com/commercialhaskell/stack/issues/2153, since its benchmarks otherwise compile unless built via `stack`.