### PR TITLE
Add back packages with working Haddocks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2874,9 +2874,6 @@ expected-haddock-failures:
     # https://github.com/fpco/stackage/issues/994
     - Michelangelo
 
-    # https://github.com/ekmett/bifunctors/issues/42
-    - bifunctors
-
     # Problem with v0.1.6.0: https://github.com/fpco/stackage/issues/1206
     - hsdev
 
@@ -2894,9 +2891,6 @@ expected-haddock-failures:
 
     # https://github.com/GetShopTV/swagger2/issues/66
     - swagger2
-
-    # https://github.com/bos/statistics/issues/93
-    - statistics
 
     # https://github.com/aelve/microlens/issues/72
     - microlens


### PR DESCRIPTION
`bifunctors` and `statistics` have since had new Hackage releases with working Haddocks, so they can be added back to Stackage.