### PR TITLE
Add back unordered-containers benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2937,10 +2937,6 @@ skipped-benchmarks:
     # https://github.com/kaizhang/clustering/issues/2
     - clustering
 
-    # Successful build requires unordered-containers >= 0.2.7.0
-    # https://github.com/fpco/stackage/issues/1226
-    - unordered-containers
-
 # end of skipped-benchmarks
 
 


### PR DESCRIPTION
[`unordered-containers-0.2.7.1`](http://hackage.haskell.org/package/unordered-containers-0.2.7.1) was released which has fixed benchmarks. Also, #1226 has been closed, so that no longer applies as a reason to hold back `unordered-containers` < 0.2.7.0.