### PR TITLE
hsdns: enable builds again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1690,8 +1690,7 @@ packages:
         - hackage-db
         # GHC 8 - hledger-interest
         - hopenssl
-        # https://github.com/fpco/stackage/issues/840
-        # - hsdns
+        - hsdns
         - hsemail
         - hsyslog
         - language-nix


### PR DESCRIPTION
The package is disabled due to https://github.com/fpco/stackage/issues/840, but that issue was fixed 9 months ago!