### PR TITLE
hledger-interest: re-enable builds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1688,7 +1688,7 @@ packages:
     "Peter Simons simons@cryp.to @peti":
         - funcmp
         - hackage-db
-        # GHC 8 - hledger-interest
+        - hledger-interest
         - hopenssl
         # https://github.com/fpco/stackage/issues/840
         # - hsdns


### PR DESCRIPTION
The package seems to compile fine with GHC 8.0.1:

  https://travis-ci.org/peti/hledger-interest/builds/136437417