### PR TITLE
Re-enable hdevtools

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -802,8 +802,7 @@ packages:
         - yesod-form-richtext
 
     "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
-        []
-        # GHC 8 - hdevtools
+        - hdevtools
 
     "Andrey Chudnov <oss@chudnov.com>":
         - language-ecmascript


### PR DESCRIPTION
Compilation against GHC 8.0.1 should be fixed with https://github.com/hdevtools/hdevtools/pull/21, released to hackage as version 0.1.3.2