### PR TITLE
Jeremy Shaw - reenable a bunch of packages which now build with GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1934,25 +1934,25 @@ packages:
         # GHC 8 - clckwrks-plugin-page
         # GHC 8 - clckwrks-plugin-media
         # GHC 8 - clckwrks-theme-bootstrap
-        # GHC 8 - hackage-whatsnew
+        - hackage-whatsnew
         # GHC 8 - happstack-authenticate
-        # GHC 8 - happstack-clientsession
+        - happstack-clientsession
         # GHC 8 - happstack-hsp
-        # GHC 8 - happstack-jmacro
-        # GHC 8 - happstack-server
-        # GHC 8 - happstack-server-tls
-        # GHC 8 - hsx-jmacro
+        - happstack-jmacro
+        - happstack-server
+        - happstack-server-tls
+        - hsx-jmacro
         # GHC 8 - ixset
         - reform
         - reform-blaze
         - reform-hamlet
-        # GHC 8 - reform-happstack
-        # GHC 8 - reform-hsp
-        # GHC 8 - userid
+        - reform-happstack
+        - reform-hsp
+        - userid
         - web-plugins
         - web-routes
-        # GHC 8 - web-routes-boomerang
-        # GHC 8 - web-routes-happstack
+        - web-routes-boomerang
+        - web-routes-happstack
         - web-routes-hsp
         - web-routes-th
         - web-routes-wai


### PR DESCRIPTION
Re-enabled a bunch of libraries that now build with GHC 8.0. The remainder of my packages have been patched and uploaded to hackage, but are blocked on pull requests to syb-with-class and ixset-typed.