### PR TITLE
Change Omari Norman's packages for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -112,7 +112,7 @@ packages:
     "Omari Norman <omari@smileystation.com>":
         - rainbow
         - rainbox
-        # GHC 8 - pipes-cliff
+        - pipes-cliff
         - anonymous-sums
         - multiarg
         - prednote
@@ -120,7 +120,7 @@ packages:
         - Earley
         - ofx
         - pinchot
-        # GHC 8 - validation
+        - accuerr
 
     "Neil Mitchell":
         - hlint


### PR DESCRIPTION
pipes-cliff should now work without changes, as the upstream
packages are now working in GHC 8.

No new release of validation has been made, so I split the
interesting parts out into a new package, accuerr.