### PR TITLE
Allow hspec-webdriver and webdriver-angular for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1454,8 +1454,8 @@ packages:
     "John Lenz <wuzzeb@gmail.com> @wuzzeb":
         - yesod-auth-account
         - yesod-static-angular
-        # GHC 8 - hspec-webdriver
-        # GHC 8 - webdriver-angular
+        - hspec-webdriver
+        - webdriver-angular
 
     "Sven Heyll <svh@posteo.de> @sheyll":
         - b9


### PR DESCRIPTION
I have tested these with nightly-2016-06-12 and they both work with GHC 8.0.1