### PR TITLE
Enable `morte` and `pipes-extras`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -444,13 +444,13 @@ packages:
     "Gabriel Gonzalez <Gabriel439@gmail.com>":
         - optparse-generic
         - pipes
-        # GHC 8 - pipes-extras
+        - pipes-extras
         - pipes-parse
         - pipes-concurrency
         - pipes-safe
         - turtle
         - foldl
-        # GHC 8 - morte
+        - morte
 
     "Andrew Thaddeus Martin <andrew.thaddeus@gmail.com>":
         - yesod-table


### PR DESCRIPTION
`morte-1.6.1` and `pipes-extras-1.0.4` now build against Stackage nightly