### PR TITLE
Add back previously broken benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2850,7 +2850,6 @@ expected-test-failures:
 expected-benchmark-failures:
     - Frames
     - attoparsec
-    - bzlib-conduit
     - cipher-aes128
     - cryptohash
     - dbus
@@ -2863,9 +2862,7 @@ expected-benchmark-failures:
     - mongoDB
     - picoparsec
     - rethinkdb
-    - stateWriter
     - thyme
-    - vinyl
     - warp
     - web-routing
     - xmlgen

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -99,7 +99,9 @@ apt-get install -y \
     libyaml-dev \
     libzip-dev \
     libzmq3-dev \
-    llvm \
+    # The LLVM version should be kept in sync with what GHC requires for its
+    # LLVM backend (see below for more information).
+    llvm-3.7 \
     m4 \
     nettle-dev \
     nodejs \
@@ -122,3 +124,11 @@ mv /opt/ghc/$GHCVER/share/doc/ghc-$GHCVER/ /opt/ghc/$GHCVER/share/doc/ghc
 # faster anyways and uses less RAM.
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
+
+# GHC requires a specific LLVM version on the system PATH for its LLVM backend.
+# This version is tracked here:
+# https://ghc.haskell.org/trac/ghc/wiki/Commentary/Compiler/Backends/LLVM/Installing
+#
+# GHC 8.0 requires LLVM 3.7 tools (specifically, llc-3.7 and opt-3.7).
+update-alternatives --install "/usr/bin/llc" "llc" "/usr/bin/llc-3.7" 50
+update-alternatives --install "/usr/bin/opt" "opt" "/usr/bin/opt-3.7" 50


### PR DESCRIPTION
This adds back `bzlib-conduit`, since a [new version](http://hackage.haskell.org/package/bzlib-conduit-0.2.1.4) was uploaded to Hackage recently with fixed benchmark compilation.

This also adds back `stateWriter` and `vinyl`, whose benchmarks require GHC's LLVM backend and weren't previously building due to an improver LLVM setup in the Debian bootstrap script. GHC's LLVM backend requires a specific version of LLVM tools (in the case of GHC 8.0, it needs `llc-3.7` and `opt-3.7`). I've updated `debian-bootstrap.sh` with comments to this effect, which should make it easy to figure out what version of LLVM to use in the future when another major version of GHC is released.