### PR TITLE
Unblock stratosphere for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2196,8 +2196,7 @@ packages:
         - protobuf-simple
 
     "David Reaver <johndreaver@gmail.com> @jdreaver":
-        []
-        # BLOCKED comonad 5 - stratosphere
+        - stratosphere
 
     "Alexey Rodiontsev <alex.rodiontsev@gmail.com> @klappvisor":
         - telegram-api


### PR DESCRIPTION
I actually had extra dependencies declared that I didn't need, so I removed them [here](https://github.com/frontrowed/stratosphere/commit/69840dbc2c8a24ff44e6915a938b6d7467f4dd0d). As a result, I got `stratosphere` to build on `nightly-2016-06-13`.