### PR TITLE
Add back bits, semigroupoids, and streams

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -249,7 +249,7 @@ packages:
         - adjunctions
         # GHC 8 - approximate
         - bifunctors
-        # GHC 8 - bits
+        - bits
         # GHC 8 - bound
         - bytes
         - charset
@@ -288,7 +288,6 @@ packages:
         - mtl
         - nats
         - numeric-extras
-        # GHC 8 
         - parsers
         - pointed
         - prelude-extras
@@ -301,7 +300,7 @@ packages:
         - semigroupoids
         - semigroups
         - speculation
-        # BLOCKED comonad 5 - streams
+        - streams
         - tagged
         - vector-instances
         - void
@@ -2463,7 +2462,6 @@ skipped-tests:
     - ad
     - composition-tree
     # GHC 8 - patches-vector
-    - semigroupoids
 
     # GHC 8 (bytestring-handle)
     - tar
@@ -2562,9 +2560,6 @@ expected-test-failures:
 
     # Requires SAT solver and old QuickCheck
     - ersatz
-
-    # Failing doctests
-    - bits
 
     # No server running
     - amqp


### PR DESCRIPTION
New versions of `bits`, `semigroupoids`, and `streams` were uploaded to Hackage, which all should work with GHC 8 (including their test suites).