### PR TITLE
Remove docvim from list of expected failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2846,9 +2846,6 @@ expected-test-failures:
 
     # https://github.com/fpco/stackage/issues/1616
     - distribution-nixpkgs
-
-    # https://github.com/wincent/docvim/issues/25
-    - docvim
 # end of expected-test-failures
 
 # Benchmarks which are known not to build. Note that, currently we do not run


### PR DESCRIPTION
[According to Travis](https://travis-ci.org/wincent/docvim/builds/138283565), the latest 0.3.1.3 release should be clean/passing.

See also: https://github.com/wincent/docvim/issues/25