### PR TITLE
Add smsaero back to Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1762,8 +1762,7 @@ packages:
 
     "Nickolay Kudasov <nickolay.kudasov@gmail.com> @fizruk":
         - http-api-data
-        # https://github.com/fpco/stackage/issues/1290
-        #- smsaero
+        - smsaero
         - swagger2
         - servant-swagger
 


### PR DESCRIPTION
`smsaero-0.5` now supports `servant-0.7` which was the problem in https://github.com/fpco/stackage/issues/1290