### PR TITLE
re-enable some hledger packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -642,8 +642,8 @@ packages:
         # GHC 8 - darcs
         - hledger
         - hledger-lib
-        - hledger-ui
-        - hledger-web
+        # - hledger-ui
+        # - hledger-web
         # GHC 8 - shelltestrunner
 
     "Mihai Maruseac <mihai.maruseac@gmail.com>":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -640,10 +640,10 @@ packages:
     "Simon Michael <simon@joyful.com> @simonmichael":
         - regex-compat-tdfa
         # GHC 8 - darcs
-        # GHC 8 - hledger
-        # GHC 8 - hledger-lib
-        # GHC 8 - hledger-ui
-        # GHC 8 - hledger-web
+        - hledger
+        - hledger-lib
+        - hledger-ui
+        - hledger-web
         # GHC 8 - shelltestrunner
 
     "Mihai Maruseac <mihai.maruseac@gmail.com>":


### PR DESCRIPTION
As best I can figure out, stackage will build these successfully in GHC8 nightlies now.

(cf https://github.com/simonmichael/hledger/issues/353)