### PR TITLE
Re-enable docvim

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2249,9 +2249,8 @@ packages:
     "Tebello Thejane <zyxoas+stackage@gmail.com> @tebello-thejane":
         - bitx-bitcoin
 
-    # incompatible with lens 4.14, process 1.4.2.0
-    # "Greg Hurrell <greg@hurrell.net>":
-    #     - docvim
+    "Greg Hurrell <greg@hurrell.net>":
+        - docvim
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Again compatible with latest lens and process packages.

Had inadvertently become incompatible as a result of switching to use the `lts-6.3` resolver instead of a recent nightly in https://github.com/wincent/docvim/commit/65c8615c82422fac3f9cd88bd5f343514ce2b496, and starting to use `--pvp-bounds both` in https://github.com/wincent/docvim/commit/29650e24d40bcdc5c3dd3eb2a0948925e421dd9e. Fixed in the 0.3.1.6 release:

https://hackage.haskell.org/package/docvim-0.3.1.6