### PR TITLE
packages about relational-record are GHC 8.0.1 ready

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2332,6 +2332,11 @@ package-flags:
     time-locale-compat:
         old-locale: false
 
+    th-data-compat:
+        template-haskell-210: false
+    th-reify-compat:
+        template-haskell-210: false
+
     HsOpenSSL:
         fast-bignum: false
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2115,9 +2115,9 @@ packages:
 
     "Kei Hibino <ex8k.hibino@gmail.com> @khibino":
         - relational-query
-        - relational-query-HDBC
-        - persistable-types-HDBC-pg
-        - relational-record
+        # GHC 8 HDBC - relational-query-HDBC
+        # GHC 8 HDBC - persistable-types-HDBC-pg
+        # GHC 8 HDBC - relational-record
         - text-ldap
         - debian-build
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2114,10 +2114,10 @@ packages:
         # GHC 8 - tidal
 
     "Kei Hibino <ex8k.hibino@gmail.com> @khibino":
-        # GHC 8 - relational-query
-        # GHC 8 - relational-query-HDBC
-        # GHC 8 - persistable-types-HDBC-pg
-        # GHC 8 - relational-record
+        - relational-query
+        - relational-query-HDBC
+        - persistable-types-HDBC-pg
+        - relational-record
         - text-ldap
         - debian-build
 


### PR DESCRIPTION
fixed following packages for GHC 8
- relational-query
- relational-query-HDBC
- persistable-types-HDBC-pg
- relational-record
