### PR TITLE
Reenable most HaskellR packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1370,11 +1370,11 @@ packages:
         - nationstates
 
     "Mathieu Boespflug <mboes@tweag.net> @mboes":
-        # GHC 8 - H
-        # GHC 8 - ihaskell-inline-r
-        # GHC 8 - inline-r
+        # BLOCKED ihaskell support for GHC 8 - ihaskell-inline-r
         - cassette
         - distributed-closure
+        - H
+        - inline-r
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":


### PR DESCRIPTION
Except ihaskell-inline-r, because package blocked by IHaskell not
supporting GHC 8.