### PR TITLE
add inline-java and sparkle, with appropriate configure flags

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2104,9 +2104,8 @@ packages:
     "Alp Mestanogullari alpmestan@gmail.com @alpmestan":
         - taggy
         - taggy-lens
-        # https://github.com/fpco/stackage/issues/1388
-        #- inline-java
-        #- sparkle
+        - inline-java
+        - sparkle
 
     "Alex McLean <lxyxpx@gmail.com> @yaxu":
         []
@@ -2376,7 +2375,8 @@ package-flags:
 
 configure-args:
   inline-java:
-  - "--FIXME"
+  - "--extra-lib-dirs /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server"
+  - "--extra-include-dirs /usr/lib/jvm/java-8-openjdk-amd64/include"
 
 # end of configure-args
 


### PR DESCRIPTION
Hello!

This is another shot at adding inline-java/sparkle now that we have the `configure-args` section in `build-constraints.yaml`.