### PR TITLE
Add webkit bindings, and re-add Gtk bindings

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2212,8 +2212,11 @@ packages:
         - gi-gio == 2.0.3
         - gi-glib == 2.0.3
         - gi-gobject == 2.0.3
-        # GHC 8 - gi-gtk == 3.0.3
+        - gi-gtk == 3.0.3
         - gi-pango == 1.0.3
+        - gi-soup == 2.4.3
+        - gi-javascriptcore == 3.0.3
+        - gi-webkit == 3.0.3
         - haskell-gi
 
     "Brandon Simmons <brandon.m.simmons@gmail.com>":
@@ -2271,9 +2274,6 @@ packages:
         # https://github.com/fpco/stackage/issues/1469
         - data-default < 0.7
         - data-default-class < 0.1
-
-        # https://github.com/fpco/stackage/issues/1477
-        - gi-javascriptcore < 3.1
 
         # https://github.com/fpco/stackage/issues/1510
         - pipes < 4.2


### PR DESCRIPTION
There is a new version of haskell-gi in stackage that improves the
binding compilation time in an important way, so re-add gi-gtk to
stackage. Perhaps this will help with
https://github.com/fpco/stackage/issues/1569 .

Also add gi-webkit to stackage, with the appropriate dependencies. This
could help with https://github.com/fpco/stackage/issues/1477 .