### PR TITLE
Add back linear-accelerate and wl-pprint-terminfo

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -280,7 +280,7 @@ packages:
         - lca
         - lens
         - linear
-        # GHC 8 - linear-accelerate
+        - linear-accelerate
         # GHC 8 - log-domain
         - machines
         - monadic-arrays
@@ -307,7 +307,7 @@ packages:
         - vector-instances
         - void
         - wl-pprint-extras
-        # GHC 8 - wl-pprint-terminfo
+        - wl-pprint-terminfo
         - zippers
         - fixed
         - half


### PR DESCRIPTION
Both [`linear-accelerate-0.2`](http://hackage.haskell.org/package/linear-accelerate-0.2) and [`wl-pprint-terminfo-3.7.14`](http://hackage.haskell.org/package/wl-pprint-terminfo-3.7.1.4) build with GHC 8.