### PR TITLE
renabled ixset and clckwrks for GHC 8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1934,20 +1934,20 @@ packages:
 
     "Jeremy Shaw <jeremy@n-heptane.com> @stepcut":
         - boomerang
-        # GHC 8 - clckwrks
-        # GHC 8 - clckwrks-cli
-        # GHC 8 - clckwrks-plugin-page
-        # GHC 8 - clckwrks-plugin-media
-        # GHC 8 - clckwrks-theme-bootstrap
+        - clckwrks
+        - clckwrks-cli
+        - clckwrks-plugin-page
+        - clckwrks-plugin-media
+        - clckwrks-theme-bootstrap
         - hackage-whatsnew
-        # GHC 8 - happstack-authenticate
+        - happstack-authenticate
         - happstack-clientsession
-        # GHC 8 - happstack-hsp
+        - happstack-hsp
         - happstack-jmacro
         - happstack-server
         - happstack-server-tls
         - hsx-jmacro
-        # GHC 8 - ixset
+        - ixset
         - reform
         - reform-blaze
         - reform-hamlet


### PR DESCRIPTION
These packages are tested individually in travis and build with GHC 8.