### PR TITLE
reenable uri-bytestring

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1337,7 +1337,7 @@ packages:
 
     "Michael Xavier <michael@michaelxavier.net> @MichaelXavier":
         - angel
-        # GHC 8 - uri-bytestring
+        - uri-bytestring
         # https://github.com/MichaelXavier/phash/issues/5
         #- phash
         - cron


### PR DESCRIPTION
It is now building on ghc-8.