### PR TITLE
Remove docvim constraint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2401,9 +2401,6 @@ packages:
         # https:/github.com/fpco/stackage/issues/1645
         - semigroups < 0.18.2
 
-        # https://github.com/fpco/stackage/issues/1648
-        - docvim < 0.3.2.0
-
 # end of packages
 
 


### PR DESCRIPTION
The issue (https://github.com/fpco/stackage/issues/1648) is fixed by https://github.com/wincent/docvim/commit/e47358de959d3d88f647db782da3550050cbf8f5 which is in the 0.3.2.1 release.

Tested with:

```
$ cabal update
$ cabal get docvim-0.3.2.0
$ cd docvim-0.3.2.0
$ stack --resolver nightly init
$ stack test # repro failure
$ # apply fix
$ stack test # see failure is no more
```