### PR TITLE
Fix opml-conduit test suite

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2978,9 +2978,6 @@ expected-test-failures:
 
     # Requries running redis - https://github.com/fpco/stackage/pull/1581
     - persistent-redis
-
-    # https://github.com/k0ral/opml-conduit/issues/4
-    - opml-conduit
 # end of expected-test-failures
 
 # Benchmarks which are known not to build. Note that, currently we do not run


### PR DESCRIPTION
Revert #1653 , now that I've updated [hackage][1] :) .

[1]: http://hackage.haskell.org/package/opml-conduit-0.5.0.1