### PR TITLE
reinstate pipes-text/lens-family/streaming

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1404,13 +1404,12 @@ packages:
         - tasty-silver
 
     "Michael Thompson <what_is_it_to_do_anything@yahoo.com> @michaelt":
-        []
-        # GHC 8 - pipes-text
-        # GHC 8 - lens-simple
-        # GHC 8 - lens-family-core
-        # GHC 8 - lens-family
-        # GHC 8 - streaming
-        # GHC 8 - streaming-bytestring
+        - pipes-text
+        - lens-simple
+        - lens-family-core
+        - lens-family
+        - streaming
+        - streaming-bytestring
 
 
     "Justin Le <justin@jle.im> @mstksg":


### PR DESCRIPTION
These all work with ghc-8 on travis, and I was able to compile them with `resolver:  nightly-2016-06-21`