### PR TITLE
Add versions, vectortiles, and pipes-random

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -581,8 +581,10 @@ packages:
 
     "Colin Woodbury <colingw@gmail.com> @fosskers":
         - microlens-aeson
+        - versions
+        - vectortiles
+        - pipes-random
         # GHC 8 - kanji
-        # GHC 8 - versions
 
     "Ketil Malde":
         - biocore


### PR DESCRIPTION
All have been updated for GHC8 support. These build against `nightly-2016-07-01`.