### PR TITLE
Add back rose-trees and warp benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3021,7 +3021,6 @@ expected-benchmark-failures:
     - picoparsec
     - rethinkdb
     - thyme
-    - warp
     - web-routing
     - xmlgen
     - yi-rope
@@ -3117,9 +3116,6 @@ skipped-benchmarks:
 
     # https://github.com/fpco/stackage/issues/1587
     - hledger-lib
-
-    # https://github.com/athanclark/rose-trees/pull/5
-    - rose-trees
 
 # end of skipped-benchmarks
 


### PR DESCRIPTION
`warp-3.2.7` and `rose-trees-0.0.4.3` are on Hackage with working benchmarks (verified with the `nightly` resolver).