### PR TITLE
Add jailbreak-cabal maintained by myself.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1814,6 +1814,7 @@ packages:
         - hsdns
         - hsemail
         - hsyslog
+        - jailbreak-cabal
         - language-nix
         - nix-paths
         - streamproc


### PR DESCRIPTION
I tried to add that tool before, but back then it wasn't possible because `jailbreak-cabal` had too specific requirements on `Cabal`. Since the switch to GHC 8.x, however, this should no longer be an issue.