### PR TITLE
Add back cryptol

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1048,7 +1048,7 @@ packages:
         - language-thrift
 
     "Adam C. Foltzer acfoltzer@galois.com @acfoltzer":
-        # GHC 8 - cryptol
+        - cryptol
         - gitrev
         - persistent-refs
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -111,6 +111,7 @@ apt-get install -y \
     stack \
     wget \
     xclip \
+    z3 \
     zip \
     zlib1g-dev
 


### PR DESCRIPTION
`cryptol-2.4.0`, recently uploaded to Hackage, builds and runs with GHC 8.0.

The benchmarks require installing `z3` to run.