### PR TITLE
Re-add solga-swagger, clang-pure, webrtc-vad

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2398,8 +2398,9 @@ packages:
 
     "Patrick Chilton <chpatrick@gmail.com>":
         - solga
-        # https://github.com/chpatrick/solga/issues/6
-        # - solga-swagger
+        - solga-swagger
+        - clang-pure
+        - webrtc-vad
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
All dependency issues should be fixed.

`clang-pure` depends on the `libclang-dev` Ubuntu package.