### PR TITLE
Enable active for stackage nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -348,7 +348,7 @@ packages:
         - picoparsec
 
     "Brent Yorgey <byorgey@gmail.com>":
-        # GHC 8 - active
+        - active
         # GHC 8 - BlogLiterately
         # GHC 8 - BlogLiterately-diagrams
         # GHC 8 - diagrams


### PR DESCRIPTION
I've tested locally and it builds (active-0.2.0.10) with GHC 8 now. 
This is my first time submitting a pull request for this repo, so here's what I did:

```
cabal unpack active
cd active-0.2.0.10/
stack init --resolver nightly --force
stack build
```