### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2405,6 +2405,9 @@ packages:
         - clang-pure
         - webrtc-vad
 
+    "Michal Konecny <mikkonecny@gmail.com>":
+        - hmpfr
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
I recently updated hmpfr to work with ghc 7.10 and 8.0.  It depends on mpfr. It compiled on hackage with ghc 8.0.  I hope it will work also in stackage.