### PR TITLE
Add tasty-rerun to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1616,6 +1616,7 @@ packages:
         # GHC 8 - libsystemd-journal
         # GHC 8 - network-carbon
         # GHC 8 - socket-io
+        - tasty-rerun
 
     "Scott Murphy scott.murphy@plowtech.net @smurphy8":
         []


### PR DESCRIPTION
It builds with GHC 8 after 1.1.6 release. @ocharles was OK with putting it on stackage.