### PR TITLE
Add back mongoDB and stache benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3,7 +3,7 @@ ghc-major-version: "8.0"
 packages:
     "Nicolas Mattia <nicolas@nmattia.com> @nmattia":
         - makefile
-        
+
     "Michael Litchard <michael@schmong.org> @mlitchard":
         - point-octree
 
@@ -159,7 +159,7 @@ packages:
 
     "Jon Schoning <jonschoning@gmail.com> @jonschoning":
         - pinboard
-        
+
     "Jasper Van der Jeugt":
         - blaze-html
         - blaze-markup
@@ -3072,7 +3072,6 @@ expected-benchmark-failures:
     - jose-jwt
     - lens
     - lucid
-    - mongoDB
     - picoparsec
     - rethinkdb
     - thyme
@@ -3086,9 +3085,6 @@ expected-benchmark-failures:
 
     # GHC 8
     - cassava
-
-    # https://github.com/stackbuilders/stache/issues/9
-    - stache
 # end of expected-benchmark-failures
 
 


### PR DESCRIPTION
Recent Hackage uploads of these packages have benchmarks that compile successfully on GHC 8.0.