### PR TITLE
Add back fast-builder

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1713,7 +1713,7 @@ packages:
         - ilist
         - text-all
 
-    "Takano Akio aljee@hyper.cx @takano-akio":
+    "Takano Akio tak@anoak.io @takano-akio":
         - fast-builder
         - filelock
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1714,7 +1714,7 @@ packages:
         - text-all
 
     "Takano Akio aljee@hyper.cx @takano-akio":
-        # GHC 8 - fast-builder
+        - fast-builder
         - filelock
 
     "Ashley Moni ashley.moni1@gmail.com @AshleyMoni":


### PR DESCRIPTION
This branch adds back `fast-builder`, which was disabled for GHC 8.

It also updates my email address.