### PR TITLE
Add back several blocked packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -779,7 +779,7 @@ packages:
         - mtl-prelude
         - neat-interpolation
         - partial-handler
-        # GHC 8 - postgresql-binary
+        - postgresql-binary
         - slave-thread
         - stm-containers
 
@@ -2692,7 +2692,6 @@ skipped-tests:
 
     # doctest < 0.11
     # Closed due to inactivity: https://github.com/fpco/stackage/issues/1328
-    - ad
     - composition-tree
     # GHC 8 - patches-vector
 
@@ -2725,9 +2724,6 @@ expected-test-failures:
 
     # https://github.com/bos/statistics/issues/42
     - statistics
-
-    # https://github.com/kazu-yamamoto/simple-sendfile/pull/10
-    - simple-sendfile
 
     # Tests require shell script and are incompatible with sandboxed package
     # databases
@@ -3118,7 +3114,6 @@ expected-benchmark-failures:
     - lens
     - lucid
     - picoparsec
-    - rethinkdb
     - thyme
     - web-routing
     - xmlgen
@@ -3181,7 +3176,6 @@ expected-haddock-failures:
 # benchmarks are included or not.
 skipped-benchmarks:
     - criterion-plus
-    - lifted-base
     - stm-containers
 
     # pulls in criterion-plus, which has restrictive upper bounds
@@ -3201,7 +3195,6 @@ skipped-benchmarks:
 
     # https://github.com/fpco/stackage/issues/494
     - case-insensitive
-    - postgresql-binary
 
     # https://github.com/kaizhang/clustering/issues/2
     - clustering


### PR DESCRIPTION
Some libraries, tests, and benchmarks which were previously blocked appear to build successfully with GHC 8.0 when I tested them. They are:

* `ad` (the doctests run as of [`4.3.2.1`](http://hackage.haskell.org/package/ad-4.3.2.1))
* `lifted-base` (the benchmarks compile as of [`0.2.3.7`](http://hackage.haskell.org/package/lifted-base-0.2.3.7))
* `postgresql-binary` (the library and benchmarks—but not the tests, due to #1691—compile as of [`0.9.0.1`](http://hackage.haskell.org/package/postgresql-binary-0.9.0.1))
* `rethinkdb` (the benchmarks compile as of [`2.2.0.6`](http://hackage.haskell.org/package/rethinkdb-2.2.0.6))
* `simple-sendfile` (the [issue](https://github.com/kazu-yamamoto/simple-sendfile/pull/10) blocking it has long been fixed)