### PR TITLE
Remove pixelated-avatar-generator from expected test failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3098,9 +3098,6 @@ expected-test-failures:
 
     # https://github.com/fpco/th-utilities/issues/2
     - th-utilities
-
-    # https://github.com/fpco/stackage/pull/1721
-    - pixelated-avatar-generator
 # end of expected-test-failures
 
 # Benchmarks which are known not to build. Note that, currently we do not run


### PR DESCRIPTION
Remove pixelated-avatar-generator from the list of expected test failures, as the test failures noted in #1721 have been fixed in version `0.1.2`.