### PR TITLE
Revert "cassava-conduit haddock fails (#1714)"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -526,9 +526,7 @@ packages:
         - posix-realtime
 
     "Dom De Re <domdere@domdere.com>":
-        []
-        # https://github.com/fpco/stackage/pull/1714
-        #- cassava-conduit
+        - cassava-conduit
 
     "Dominic Steinitz <dominic@steinitz.org>":
         - yarr


### PR DESCRIPTION
This reverts commit 3355d666e8aa56ddbabb4596f7295ab51a194aba.

Fixed up the haddock doc build issue