### PR TITLE
Add back previously blocked tests and benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3,7 +3,7 @@ ghc-major-version: "8.0"
 packages:
     "Aaron Taylor <aaron@hamsterdam.co> @hamsterdam":
         - kawhi
- 
+
     "Schell Scivally <schell@zyghost.com> @schell":
         - renderable
         - varying
@@ -2614,7 +2614,6 @@ skipped-tests:
     - list-t
     - postgresql-binary
     - slave-thread
-    - stm-containers
 
     # Just a temporary package with a flimsy, inherited test suite
     - Cabal-ide-backend
@@ -2637,12 +2636,6 @@ skipped-tests:
     # https://github.com/fpco/stackage/issues/934
     - cacophony
 
-    # Build error with lens-4.13
-    # https://github.com/brendanhay/amazonka/issues/251
-    - amazonka-ec2
-    - amazonka-s3
-    - amazonka-swf
-
     # Misc from GHC 7.10.3 upgrade
     # https://github.com/fpco/stackage/issues/1045
     #- argon
@@ -2664,8 +2657,6 @@ skipped-tests:
     - yesod-static-angular
     # https://github.com/fpco/stackage/pull/906
     - HaRe
-    # https://github.com/Deewiant/glob/issues/1
-    - Glob
 
     # https://github.com/haskell/zlib/issues/2
     - zlib
@@ -2708,9 +2699,6 @@ skipped-tests:
 
     # Missing C library: symengine
     - symengine
-
-    # https://github.com/athanclark/rose-trees/pull/5
-    - rose-trees
 
 # end of skipped-tests
 
@@ -2908,9 +2896,6 @@ expected-test-failures:
     # https://github.com/gibiansky/IHaskell/issues/551
     - ihaskell
 
-    # https://github.com/well-typed/ixset-typed/issues/2
-    - ixset-typed
-
     # Expects running X server
     - bindings-GLFW
     - GLFW-b
@@ -3034,9 +3019,6 @@ expected-test-failures:
     # https://github.com/IreneKnapp/direct-sqlite/issues/63
     - direct-sqlite
 
-    # https://github.com/well-typed/hackage-security/issues/164
-    - hackage-security
-
     # GHC 8 issue not reported upstream since issue tracker disabled
     - hspec-expectations-pretty-diff
 
@@ -3066,9 +3048,6 @@ expected-test-failures:
 
     # Requries running redis - https://github.com/fpco/stackage/pull/1581
     - persistent-redis
-
-    # https://github.com/tfausak/octane/issues/35
-    - octane
 
     # https://github.com/fosskers/vectortiles/issues/2
     - vectortiles
@@ -3100,7 +3079,6 @@ expected-benchmark-failures:
     - cipher-aes128
     - cryptohash
     - dbus
-    - gitson
     - hashable
     - http-link-header
     - jose-jwt
@@ -3158,9 +3136,6 @@ expected-haddock-failures:
 
     # https://github.com/iand675/metrics/issues/5
     - metrics
-
-    # https://github.com/fpco/stackage/pull/1549
-    - ghc-exactprint
 # end of expected-haddock-failures
 
 
@@ -3169,7 +3144,6 @@ expected-haddock-failures:
 # benchmarks are included or not.
 skipped-benchmarks:
     - criterion-plus
-    - stm-containers
 
     # pulls in criterion-plus, which has restrictive upper bounds
     - cases
@@ -3182,12 +3156,6 @@ skipped-benchmarks:
     - cipher-camellia
     - cipher-des
     - cipher-rc4
-
-    # sometimes falls out-of-sync on hasql-postgres
-    - hasql
-
-    # https://github.com/fpco/stackage/issues/494
-    - case-insensitive
 
     # https://github.com/kaizhang/clustering/issues/2
     - clustering


### PR DESCRIPTION
They include:

* `stm-containers` (version [`0.2.14`](http://hackage.haskell.org/package/stm-containers-0.2.14) has working tests and benchmarks)
* `gitson` (version [`0.5.2`](http://hackage.haskell.org/package/gitson-0.5.2) has working benchmarks)
* `amazonka-ec2`, `-s3`, and `-swf` tests (since https://github.com/brendanhay/amazonka/issues/251 was fixed)
* `Glob` tests (since https://github.com/Deewiant/glob/issues/1 was fixed)
* `ixset-typed` tests (since https://github.com/well-typed/ixset-typed/issues/2 was fixed)
* `rose-trees` tests (since https://github.com/athanclark/rose-trees/pull/5 was fixed)
* `octane` tests (since https://github.com/tfausak/octane/issues/35 was fixed)
* `hackage-security` tests (since https://github.com/well-typed/hackage-security/issues/164 was fixed)
* `case-insensitive` (version [`1.2.0.7`](http://hackage.haskell.org/package/case-insensitive-1.2.0.7) has working benchmarks)
* `hasql` (version [`0.19.13`](http://hackage.haskell.org/package/hasql-0.19.13) has working benchmarks)
* `ghc-exactprint` haddocks (since https://github.com/fpco/stackage/pull/1549 was fixed)