### PR TITLE
Remove constraint "safe-exceptions < 0.1.4"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2516,9 +2516,6 @@ packages:
         # https://github.com/fpco/stackage/issues/1717
         - dlist < 0.8
 
-        # https://github.com/snoyberg/mono-traversable/issues/104
-        - safe-exceptions < 0.1.4
-
         # https://github.com/fpco/stackage/issues/1733
         - tagged < 0.8.5
 


### PR DESCRIPTION
The related issue appears to have been addressed: https://github.com/snoyberg/mono-traversable/issues/104