### PR TITLE
Update build-constraints.yaml - monad-parallel & monad-coroutine build with GHC 8.0.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -350,8 +350,8 @@ packages:
         - base-compat
 
     "Mario Blazevic <blamario@yahoo.com> @blamario":
-        # GHC 8 - monad-parallel
-        # GHC 8 - monad-coroutine
+        - monad-parallel
+        - monad-coroutine
         - incremental-parser
         - monoid-subclasses
         - picoparsec


### PR DESCRIPTION
Current versions of monad-parallel and monad-coroutine build with GHC 8.0.1 without any problems.