### PR TITLE
Re-enable ghc-events

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -742,7 +742,7 @@ packages:
         - parallel-io
         - text-binary
         - Chart-cairo
-        # GHC 8 - ghc-events
+        - ghc-events
         - monad-extras
         - stack < 9.9.9
         - optparse-simple


### PR DESCRIPTION
`ghc-events`' upper version bound on `binary` [was relaxed](http://hackage.haskell.org/package/ghc-events-0.4.4.0/revisions/) on Hackage, so now it builds with GHC 8.