### PR TITLE
Re-enable ghc-mod

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -678,7 +678,7 @@ packages:
         # UNKNOWN VERSION Compilation failure https://github.com/d12frosted/CanonicalPath/issues/5 - system-canonicalpath
 
     "Daniel Gröber <dxld@darkboxed.org> @DanielG":
-        # GHC 8 & bounds - ghc-mod
+        - ghc-mod
         - cabal-helper
 
     "Yann Esposito <yann.esposito@gmail.com>":


### PR DESCRIPTION
ghc-mod-5.6 lifts the GHC 8 bounds problem.