### PR TITLE
Remove microlens from expected Haddock failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3138,9 +3138,6 @@ expected-haddock-failures:
     # https://github.com/GetShopTV/swagger2/issues/66
     - swagger2
 
-    # https://github.com/aelve/microlens/issues/72
-    - microlens
-
     # https://github.com/iand675/metrics/issues/5
     - metrics
 


### PR DESCRIPTION
Haddocks have been fixed in microlens-0.4.7.