### PR TITLE
Restore wai-predicates, list-t, slave-thread tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -702,7 +702,7 @@ packages:
         - redis-io
         - swagger
         - tinylog
-        # GHC 8 - wai-predicates
+        - wai-predicates
         # GHC 8 - wai-routing
         - zeromq4-haskell
 
@@ -2383,7 +2383,7 @@ packages:
 
     "Anton Gushcha <ncrashed@gmail.com> @ncrashed":
         - aeson-injector
-        
+
     "Rune K. Svendsen <runesvend@gmail.com> @runeks":
         - bitcoin-payment-channel
 
@@ -2573,9 +2573,7 @@ skipped-tests:
 
     # Too lazy to keep the test dependencies up to date
     - cases
-    - list-t
     - postgresql-binary
-    - slave-thread
 
     # Just a temporary package with a flimsy, inherited test suite
     - Cabal-ide-backend
@@ -2975,9 +2973,6 @@ expected-test-failures:
 
     # https://github.com/fpco/stackage/pull/1254
     - graylog
-
-    # https://github.com/fpco/stackage/issues/1412
-    - wai-predicates
 
     # https://github.com/stbuehler/haskell-nettle/issues/8
     - nettle


### PR DESCRIPTION
* `wai-predicates-0.9.0` is on Hackage with a test suite that works with GHC 8.
* `list-t-1` and `slave-thread-1.0.2` are on Hackage with up-to-date dependencies for its test suites.

Fixes #1412.