### PR TITLE
Add package `hailgun`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1713,6 +1713,7 @@ packages:
     "Dennis Gosnell <cdep.illabout@gmail.com> @cdepillabout":
         - envelope
         # GHC 8 - ig
+        - hailgun
         - natural-transformation
         - opaleye-trans
         - read-env-var


### PR DESCRIPTION
This commit adds the package [`hailgun`](https://hackage.haskell.org/package/hailgun).

`hailgun` is a Haskell client for the [Mailgun](https://www.mailgun.com/) web service.