### PR TITLE
Re-enable ede package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1215,7 +1215,7 @@ packages:
         - gogol-youtube
         - gogol-youtube-analytics
         - gogol-youtube-reporting
-        # 0.2.8.4 compilation failure - ede
+        - ede
         - pagerduty
         - semver
         - text-manipulate


### PR DESCRIPTION
Updated to compile with the new(est) version of `trifecta`.

cc @bergmark 

References: https://github.com/brendanhay/ede/issues/17, https://github.com/brendanhay/ede/pull/18
