### PR TITLE
Add xmlhtml independently of snap

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -692,6 +692,7 @@ packages:
 
     "Paul Rouse <pgr@doynton.org>":
         - sphinx
+        - xmlhtml
         - yesod-auth-hashdb
 
     "Toralf Wittner <tw@dtex.org> @twittner":


### PR DESCRIPTION
`snap` would bring this in, but is not in nightly at the moment - seems useful to have this independently.