### PR TITLE
Remove upper bounds for `irc-dcc` and `xdcc`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2484,10 +2484,6 @@ packages:
         # https://github.com/fpco/stackage/issues/1796
         - generic-deriving < 1.11
         - text-show < 3.4
-
-        # https://github.com/fpco/stackage/issues/1800
-        - irc-dcc < 2.0.0
-        - xdcc < 1.1.0
 # end of packages
 
 


### PR DESCRIPTION
`xdcc-1.1.2` fixes #1800.