### PR TITLE
debian-bootstrap.sh: Install ghc-dyn and ghc-prof.

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -35,6 +35,8 @@ apt-get update
 apt-get install -y \
     build-essential \
     ghc-$GHCVER \
+    ghc-$GHCVER-dyn \
+    ghc-$GHCVER-prof \    
     ghc-$GHCVER-htmldocs \
     hscolour \
     sudo \


### PR DESCRIPTION
This is required to make Cabal's test suite work correctly.