### PR TITLE
Re-enable cipher-aes128 benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2851,7 +2851,6 @@ expected-benchmark-failures:
 
     # Compilation failures
     - Frames # https://github.com/acowley/Frames/issues/47
-    - cipher-aes128 # https://github.com/TomMD/cipher-aes128/issues/11
     - cryptohash # https://github.com/vincenthz/hs-cryptohash/pull/43
     - dbus # No issue tracker, sent e-mail to maintainer
     - http-link-header # https://github.com/myfreeweb/http-link-header/pull/4


### PR DESCRIPTION
https://github.com/TomMD/cipher-aes128/issues/11#issuecomment-243003456