### PR TITLE
Re-enable Cabal tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2705,7 +2705,6 @@ expected-test-failures:
     # Requires running servers, accounts, or a specific
     # environment. These shouldn't be re-enabled unless we know a fix
     # has been released.
-    - Cabal
     - GLFW-b # X
     - HTF # Requires shell script and are incompatible with sandboxed package databases
     - HaRe # # Needs ~/.ghc-mod/cabal-helper https://github.com/fpco/stackage/pull/906


### PR DESCRIPTION
This requires pulling the latest docker image

Ping @23Skidoo 
