### PR TITLE
Re-enable http-link-header benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2854,7 +2854,6 @@ expected-benchmark-failures:
     - cipher-aes128 # https://github.com/TomMD/cipher-aes128/issues/11
     - cryptohash # https://github.com/vincenthz/hs-cryptohash/pull/43
     - dbus # No issue tracker, sent e-mail to maintainer
-    - http-link-header # https://github.com/myfreeweb/http-link-header/pull/4
     - jose-jwt # https://github.com/tekul/jose-jwt/issues/12
     - lens # https://github.com/ekmett/lens/issues/672
     - lucid # https://github.com/chrisdone/lucid/pull/52


### PR DESCRIPTION
Should be fixed in v1.0.2.