### PR TITLE
Restore cipher-aes128 benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2866,7 +2866,6 @@ expected-benchmark-failures:
 
     # Compilation failures
     - Frames # https://github.com/acowley/Frames/issues/47
-    - cipher-aes128 # https://github.com/TomMD/cipher-aes128/issues/12
     - cryptohash # https://github.com/vincenthz/hs-cryptohash/pull/43
     - dbus # No issue tracker, sent e-mail to maintainer
     - jose-jwt # https://github.com/tekul/jose-jwt/issues/12


### PR DESCRIPTION
[`cipher-aes128-0.7.0.3.`](http://hackage.haskell.org/package/cipher-aes128-0.7.0.3) fixed the benchmarks... again.