### PR TITLE
Repa family

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -603,6 +603,9 @@ packages:
         - versions
         - vectortiles
         - pipes-random
+        - repa
+        - repa-io
+        - repa-algorithms
         # GHC 8 - kanji
 
     "Ketil Malde @ketil-malde":


### PR DESCRIPTION
Between LTS-6 and the latest nightlies, `repa` was removed. The maintainer of the repa-* packages doesn't use stackage, but has given me permission to add them back. They build successfully with `nightly-2016-09-01`.