### PR TITLE
Drop H from expected-test-failures.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2801,7 +2801,6 @@ expected-test-failures:
     # Assertion failures, these can be real bugs or just limitations
     # in the test cases.
     - DRBG # https://github.com/TomMD/DRBG/issues/7
-    - H # https://github.com/tweag/HaskellR/issues/259
     - clash-prelude # 0.10.14 Runtime errors https://github.com/clash-lang/clash-prelude/issues/57
     - direct-sqlite # 2.3.17 https://github.com/IreneKnapp/direct-sqlite/issues/63
     - ed25519 # 0.0.5.0 https://github.com/thoughtpolice/hs-ed25519/issues/15


### PR DESCRIPTION
Release H-0.9.0.1 fixes this issue.