### PR TITLE
Remove purescript from Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1050,12 +1050,6 @@ packages:
         # GHC 8 - regex-tdfa-utf8
         # 0.91 Compilation failure due to -Werror - regex-tre
 
-        # Purescript
-        - bower-json
-        - boxes
-        - pattern-arrows
-        - purescript
-
         # Universe
         - universe
         - universe-base
@@ -2462,6 +2456,13 @@ packages:
     # See https://github.com/fpco/stackage/issues/1056
     "Abandoned packages":
         - curl
+
+        # Purescript
+        - bower-json
+        - boxes
+        - pattern-arrows
+        - purescript
+
 
      # If you want to make sure a package is removed from stackage,
      # place it here with a `< 0` constraint and send a pull


### PR DESCRIPTION
I don't want to receive purescript related notifications anymore.
If actual maintainers want to claim, and un-abandon `purescript`, they are free to do it.

Outcome of https://github.com/purescript/purescript/issues/2293 discussion