### PR TITLE
Fix #1799

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2517,7 +2517,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/1764
         - aeson < 1.0
-        - insert-ordered-containers < 0.2
 
         # https://github.com/fpco/stackage/issues/1767
         - SVGFonts < 1.6


### PR DESCRIPTION
Nothing is blocking `insert-ordered-containers-0.2` from entering Nightly, except no `aeson-1` there yet.