### PR TITLE
Reactivate country-codes by adding package flag

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -402,7 +402,7 @@ packages:
         # - yesod-auth-oauth2 # BLOCKED http-client 0.5
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
-        # bounds - country-codes
+        - country-codes
         # bounds - esqueleto
         # - fb # BLOCKED http-conduit 2.2
         # bounds - fb-persistent
@@ -2617,6 +2617,9 @@ package-flags:
     ghc-heap-view:
         ghc_7_7: false
         ghc_8_0: true
+        
+    country-codes:
+        generate: false
 
 # end of package-flags
 


### PR DESCRIPTION
country-codes depends on tagsoup only for generating the data file.
Try building it with the generate flag explicitly set to false.

Note that a pull request is already filed for relaxing the version bound on tagsoup, but until then, this could help bringing country-codes back into nightly.