### PR TITLE
Re-enable cabal2nix builds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1835,7 +1835,7 @@ packages:
 
     "Peter Simons <simons@cryp.to> @peti":
         - distribution-nixpkgs
-        # - cabal2nix # BLOCKED aeson 1.0
+        - cabal2nix
         - funcmp
         - hackage-db
         - hledger-interest


### PR DESCRIPTION
Support for aeson 1.x has been added in version 2.0.2.