### PR TITLE
Remove arithmoi from skipped-tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2681,7 +2681,6 @@ skipped-tests:
     # QuickCheck 2.9
     - Cabal
     - ChasingBottoms
-    - arithmoi
     - bytestring-handle
     - cgi
     - ed25519
@@ -3052,6 +3051,10 @@ github-users:
         - klappvisor
     fpinsight:
         - thierry-b
+    arithmoi:
+        - Bodigrim
+        - cartazio
+        - phadej
 
 # end of github-users
 


### PR DESCRIPTION
Arithmoi 0.4.3.0 has been released with support of QuickCheck 2.9. 
I have also added myself to maintainers list to be pinged about future failures.