### PR TITLE
add avwx

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2122,6 +2122,7 @@ packages:
         - yes-precure5-command
 
     "Hans-Christian Esperer <hc@hcesperer.org> @hce":
+        - avwx
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":


### PR DESCRIPTION
avwx is a package that can parse aviation weather reports. Currently limited to
METARs (aerodrome weather observation reports), plans exist to add support for
other types of aviation weather reports such as terminal forecasts (TAFs).