### PR TITLE
Add back conduit-connection

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2038,7 +2038,7 @@ packages:
 
     "Sebastian Dröge slomo@coaxion.net @sdroege":
         - conduit-iconv
-        # GHC 8 - conduit-connection
+        - conduit-connection
 
     "Andrew Rademacher <andrewrademacher@gmail.com> @AndrewRademacher":
         - aeson-casing


### PR DESCRIPTION
0.1.0.2 works with GHC 8 after the transformers upper bound was
increased.

See also https://github.com/fpco/stackage/issues/1907