### PR TITLE
Remove `sodium` package from Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -832,7 +832,6 @@ packages:
         - zip-archive
 
     "Arthur Fayzrakhmanov <heraldhoi@gmail.com> @geraldus":
-        # GHC 8 - sodium
         - yesod-form-richtext
         - ghcjs-perch
 


### PR DESCRIPTION
I've added this package long ago because I was asked to by package author.  When first build issues were reported I sent an email to author asking him to take maintenance in his hands but received no answer so far.