### PR TITLE
Re-enable `reedsolomon`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2222,8 +2222,8 @@ packages:
     "Lennart Kolmodin <kolmodin@gmail.com> @kolmodin":
         - binary-bits
 
-    # "Nicolas Trangez <ikke@nicolast.be> @NicolasT":
-        # GHC 8 - reedsolomon
+    "Nicolas Trangez <ikke@nicolast.be> @NicolasT":
+        - reedsolomon
 
     "Alp Mestanogullari <alpmestan@gmail.com> @alpmestan":
         - taggy


### PR DESCRIPTION
`reedsolomon-0.0.4.1`, now available from Hackage, supports GHC 8 and
Stackage LTS 7.

See: cb54d78615c0e154913007e9437ff30de6e13661
See: https://github.com/fpco/stackage/issues/1907
See: https://github.com/NicolasT/reedsolomon/releases/tag/reedsolomon-0.0.4.1