### PR TITLE
Revert "Disable jose-jwt test suite tekul/jose-jwt#13"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2831,7 +2831,6 @@ expected-test-failures:
     - haskell-names # 0.7.0 https://github.com/haskell-suite/haskell-names/issues/78
     - rematch # No issue tracker, sent e-mail to maintainer https://github.com/fpco/stackage/issues/376
     - xlsior # https://github.com/rcallahan/xlsior/issues/1
-    - jose-jwt # https://github.com/tekul/jose-jwt/issues/13
 
     # Assertion failures, these can be real bugs or just limitations
     # in the test cases.


### PR DESCRIPTION
Version 0.7.3 now has the missing test file added to extra-source-files