### PR TITLE
Re-enabled camfort and fortran-src

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2434,9 +2434,9 @@ packages:
 
     "Dominic Orchard <dom.orchard@gmail.com> @dorchard":
         - array-memoize
-        # - camfort # BLOCKED haskell-src-exts 1.18 via fortran-src
+        - camfort
         # - codo-notation # BLOCKED haskell-src-exts 1.18
-        # - fortran-src # haskell-src-exts 1.18 via derive
+        - fortran-src
         # 0.57 Compilation failure https://github.com/fpco/stackage/pull/1710#issuecomment-235067168 - ixmonad
         - language-fortran
 


### PR DESCRIPTION
Their dependencies on haskell-src-exts and derive have been removed.