### PR TITLE
Enabled hdocs, hsdev: fail test was removed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -873,9 +873,9 @@ packages:
         - servant-cassava
 
     "Alexandr Ruchkin <voidex@live.com> @mvoidex":
-        # missing test files https://github.com/fpco/stackage/issues/1562 - hdocs
+        - hdocs
         - hformat
-        # missing test files https://github.com/fpco/stackage/issues/1562 - hsdev
+        - hsdev
         - simple-log
         - text-region
 


### PR DESCRIPTION
I've removed test according to #1562 