### PR TITLE
Enable ‘hspec-megaparsec’ version 0.3.0 and higher

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2558,9 +2558,6 @@ packages:
         - hspec-core < 2.2.4
         - hspec-discover < 2.2.4
 
-        # https://github.com/fpco/stackage/issues/1929
-        - hspec-megaparsec < 0.3.0
-
         # https://github.com/haskell-works/hw-rankselect/issues/2
         - hw-prim ==0.1.0.3
         - hw-bits ==0.1.0.1


### PR DESCRIPTION
See #1929.