### PR TITLE
reenable hsx2hs and packages that were blocked by it

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2061,15 +2061,15 @@ packages:
 
     "Jeremy Shaw <jeremy@n-heptane.com> @stepcut":
         - boomerang
-        # - clckwrks # haskell-src-exts 1.18 via hsx2hs
-        # - clckwrks-cli # haskell-src-exts 1.18 via hsx2hs
-        # - clckwrks-plugin-page # haskell-src-exts 1.18 via hsx2hs
-        # - clckwrks-plugin-media # haskell-src-exts 1.18 via hsx2hs
-        # - clckwrks-theme-bootstrap # haskell-src-exts 1.18 via hsx2hs
+        - clckwrks
+        - clckwrks-cli
+        - clckwrks-plugin-page
+        - clckwrks-plugin-media
+        - clckwrks-theme-bootstrap
         - hackage-whatsnew
-        # - happstack-authenticate # haskell-src-exts 1.18 via hsx2hs
+        - happstack-authenticate
         - happstack-clientsession
-        # - happstack-hsp # haskell-src-exts 1.18 via hsx2hs
+        - happstack-hsp
         # - happstack-jmacro # BLOCKED haskell-src-exts 1.18 via jmacro
         - happstack-server
         - happstack-server-tls
@@ -2079,7 +2079,7 @@ packages:
         - reform-blaze
         - reform-hamlet
         - reform-happstack
-        # - reform-hsp # haskell-src-exts 1.18 via hsx2hs
+        - reform-hsp
         - userid
         - web-plugins
         - web-routes
@@ -2088,7 +2088,7 @@ packages:
         - web-routes-hsp
         - web-routes-th
         - web-routes-wai
-        # - hsx2hs # BLOCKED haskell-src-exts 1.18
+        - hsx2hs
 
     "Pedro Tacla Yamada <tacla.yamada@gmail.com> @yamadapc":
         - ascii-progress


### PR DESCRIPTION
After one monster of a patch (almost 600 lines modified), hsx2hs 0.14 now supports haskell-src-exts 1.18.