### PR TITLE
Re-enable yahoo-finance-api package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1766,7 +1766,7 @@ packages:
         - natural-transformation
         - opaleye-trans
         - read-env-var
-        # - yahoo-finance-api # https://github.com/cdepillabout/yahoo-finance-api/issues/1
+        - yahoo-finance-api
 
     "Franklin Chen <franklinchen@franklinchen.com> @FranklinChen":
         - Ebnf2ps
@@ -2859,6 +2859,7 @@ expected-test-failures:
     - wai-cors # PhantomJS
     - wai-session-postgresql # PostgreSQL
     - webdriver-angular # webdriver server
+    - yahoo-finance-api # Requires being able to access Yahoo Finance API
 
     # Deprecated
     # Eventually we'll have to disable these packages completely.


### PR DESCRIPTION
I fixed the [problems](https://github.com/cdepillabout/yahoo-finance-api/issues/1) with this package so I am re-enabling it.

The tests depend on the actual Yahoo Finance API, so I have added it to the `expected-test-failures` section.