### PR TITLE
Revert "Temporary block factisresearch/large-hashable#10"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -222,8 +222,7 @@ packages:
         - HTF
         - xmlgen
         - stm-stats
-        # https://github.com/factisresearch/large-hashable/issues/10
-        # - large-hashable
+        - large-hashable
 
     "Bart Massey <bart.massey+stackage@gmail.com> @BartMassey":
         - parseargs


### PR DESCRIPTION
This reverts commit c10c345b425ae096bcab6f67dba0db9478de12a9.