### PR TITLE
Add back mysql and mysql-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -737,6 +737,8 @@ packages:
         - ekg-json
 
     "Paul Rouse <pgr@doynton.org> @paul-rouse":
+        - mysql
+        - mysql-simple
         - sphinx
         - xmlhtml
         - yesod-auth-hashdb


### PR DESCRIPTION
The `mysql` and `mysql-simple` packages are repaired now (I am the new maintainer).

Being cautious, I have held off re-enabling packages blocked on these - I'll PR that separately, if you like, when these two have successfully gone into nightly.