### PR TITLE
Expect test fail for mysql-simple, too - no server

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2878,6 +2878,7 @@ expected-test-failures:
     - memcached-binary # memcached
     - mongoDB # mongoDB - https://github.com/mongodb-haskell/mongodb/issues/61
     - mysql # MySQL
+    - mysql-simple # MySQL
     - network-anonymous-i2p
     - opaleye # PostgreSQL
     - persistent-redis # redis - https://github.com/fpco/stackage/pull/1581


### PR DESCRIPTION
You'll need to exclude the mysql-simple test too - sorry, I forgot about this problem.