### PR TITLE
Un-skip data-msgpack benchmarks.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3063,7 +3063,6 @@ skipped-benchmarks:
     - cipher-camellia # https://github.com/vincenthz/hs-crypto-cipher/issues/46
     - cipher-des # https://github.com/vincenthz/hs-crypto-cipher/issues/46
     - cipher-rc4 # https://github.com/vincenthz/hs-crypto-cipher/issues/46
-    - data-msgpack # https://github.com/TokTok/hs-msgpack/issues/20
 
     # GHC Bugs
     - hledger-lib # https://github.com/fpco/stackage/issues/1587


### PR DESCRIPTION
... as they are now fixed. https://github.com/TokTok/hs-msgpack/issues/20 - fixed in 0.0.6.