### PR TITLE
Uncommented pandoc, pandoc-citeproc.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2201,8 +2201,8 @@ packages:
         - pandoc-types
         - zip-archive
         - doctemplates
-        # - pandoc # BLOCKED aeson 1.0
-        # - pandoc-citeproc # BLOCKED aeson 1.0
+        - pandoc
+        - pandoc-citeproc
 
     "Karun Ramakrishnan <karun012@gmail.com> @karun012":
         - doctest-discover


### PR DESCRIPTION
pandoc 1.18 and pandoc-citeproc 0.10.2.2 will both compile
against aeson 1.0.2.1.