### PR TITLE
add patat

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -198,7 +198,7 @@ packages:
         - cabal-dependency-licenses
         # - hakyll # QuickCheck, snap-server, via pandoc, via pandoc-citeproc
         - stylish-haskell
-        # - patat # BLOCKED via pandoc
+        - patat
         - profiteur
         - psqueues
         - websockets


### PR DESCRIPTION
pandoc is enabled again in lts, so patat should be able to build.