### PR TITLE
Removed package 'biophd'

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -649,7 +649,6 @@ packages:
         # 0.3.7.1 Compilation failure due to -Werror - biosff
         - blastxml
         - bioace
-        # 0.8.8 Compilation failure https://github.com/BioHaskell/biophd/issues/3 - biophd
         - biopsl
         # VERSION MISSING Compilation failure against c2hs https://github.com/ingolia/SamTools/issues/3 - samtools
         - seqloc


### PR DESCRIPTION
Addressing issue: https://github.com/BioHaskell/biophd/issues/3

Package 'biophd' is not being regularly maintained.