### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2451,9 +2451,9 @@ packages:
         - text-conversions
 
     "Patrick Chilton <chpatrick@gmail.com> @chpatrick":
-        # - solga # BLOCKED aeson-qq
-        # - solga-swagger # aeson-qq
-        # Doesn't build on stackage server https://github.com/fpco/stackage/pull/1692 - clang-pure
+        - solga
+        - solga-swagger
+        - clang-pure
         - webrtc-vad
 
     "Michal Konecny <mikkonecny@gmail.com> @michalkonecny":


### PR DESCRIPTION
`solga`/`solga-swagger` now work with `aeson >= 1.0.0.0`, `clang-pure` has a new `Setup.hs` that should make it work everywhere.