### PR TITLE
add hailgun-simple package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1792,6 +1792,7 @@ packages:
         - envelope
         - from-sum
         - hailgun
+        - hailgun-simple
         # GHC 8 - ig
         - natural-transformation
         - opaleye-trans


### PR DESCRIPTION
This adds the [hailgun-simple](https://hackage.haskell.org/package/hailgun-simple) package.