### PR TITLE
re-add gpipe

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1820,11 +1820,11 @@ packages:
 
         - yi-rope
 
-    # "Tobias Bexelius <tobias_bexelius@hotmail.com> @tobbebex":
-        # GHC 8 - GPipe
+    "Tobias Bexelius <tobias_bexelius@hotmail.com> @tobbebex":
+        - GPipe
 
-    # "Patrick Redmond <plredmond@gmail.com> @plredmond":
-        # GHC 8 - GPipe-GLFW
+    "Patrick Redmond <plredmond@gmail.com> @plredmond":
+        - GPipe-GLFW
 
     # "Csaba Hruska <csaba.hruska@gmail.com> @csabahruska":
         # GHC 8 - lambdacube-ir


### PR DESCRIPTION
GPipe-GLFW 1.2.4 and GPipe 2.1.8 are ready to be back in stackage.