### PR TITLE
Revert "cassava-conduit upper bound for #2065"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2656,8 +2656,6 @@ packages:
         - vty < 5.12
         - text-zipper < 0.9
 
-        # https://github.com/fpco/stackage/issues/2065
-        - cassava-conduit < 0.3.5
 # end of packages
 
 


### PR DESCRIPTION
This reverts commit 95e951c11ada758f8c8e7f51e4023978f856e031.

Got this resolved in the project now