### PR TITLE
Remove @jpvillaisaza from @stackbuilders group

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3136,7 +3136,6 @@ github-users:
     stackbuilders:
         - sestrella
         - jsl
-        - jpvillaisaza
         - jsantos17
         - mrkkrp
     scotty-web:


### PR DESCRIPTION
This pull request removes my username from the Stack Builders group. I'll stop working at Stack Builders soon, so I should stop receiving notifications for some packages.