### PR TITLE
dont skip rotating-log test suite

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2811,9 +2811,6 @@ skipped-tests:
     - options # QuickCheck via chell-quickcheck
     - uri-bytestring # haskell-src-exts via derive
 
-    # Dependencies missing from cabal file
-    - rotating-log # 0.4.1 https://github.com/Soostone/rotating-log/pull/2
-
     # Blocked by stackage upper bounds. These can be re-enabled once
     # the relevant stackage upper bound is lifted.
 


### PR DESCRIPTION
I've relased 0.4.2 with the missing dependency in the cabal file.