### PR TITLE
Reenable cron and packages blocked by it

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1501,7 +1501,7 @@ packages:
         - angel
         - uri-bytestring
         # Can't build on stackage server https://github.com/MichaelXavier/phash/issues/5 - phash
-        # - cron # BLOCKED derive
+        - cron
         # GHC 8 - tasty-tap
         # via tasty-tap - tasty-fail-fast
         - drifter
@@ -2346,8 +2346,7 @@ packages:
         - protolude
 
     "Daishi Nakajima <nakaji.dayo@gmail.com> @nakaji_dayo":
-        []
-        # - yesod-job-queue # BLOCKED cron
+        - yesod-job-queue
 
     # "Braden Walters <vc@braden-walters.info> @meoblast001":
         # - hakyll-sass


### PR DESCRIPTION
I'm not familiar with yesod-job-queue but if the comment is correct, reenabling cron means it can also come back. I went ahead and purged derive from cron, opting instead for generics-sop. According to travis, my build should be working for nightlies and recent lts.