### PR TITLE
Reintroduce ua-parser

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2246,7 +2246,7 @@ packages:
         - string-conv
         - rng-utils
         - rotating-log
-        # - ua-parser # BLOCKED derive
+        - ua-parser
         - hs-GeoIP
         - retry
         # GHC 8 - katip


### PR DESCRIPTION
ua-parser as of 0.7.2 does not depend on derive for its test suite anymore. Tests run from lts-2 to nightly and all are passing.