### PR TITLE
Don't skip retry tests anymore

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2779,7 +2779,6 @@ skipped-tests:
     - parsec
     - psqueues
     - rank1dynamic
-    - retry
     - stylish-haskell
     - threads
     - tz


### PR DESCRIPTION
As of retry 0.7.4.2, it permits HUnit 1.5, so we should be good to test again.