### PR TITLE
Resume running tests for uri-bytestring

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2820,7 +2820,6 @@ skipped-tests:
     - MissingH # via testpack https://github.com/jgoerzen/testpack/issues/11
     - clustering # via RLang-QQ via HList https://github.com/kaizhang/clustering/issues/2 (also sent e-mail to HList maintainer)
     - options # QuickCheck via chell-quickcheck
-    - uri-bytestring # haskell-src-exts via derive
 
     # Blocked by stackage upper bounds. These can be re-enabled once
     # the relevant stackage upper bound is lifted.


### PR DESCRIPTION
I've dropped the dependency on derive in uri-bytestring 0.2.2.1