### PR TITLE
Unblock bloodhound

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -516,7 +516,7 @@ packages:
     "Chris Allen <cma@bitemyapp.com> bitemyapp":
         - machines-directory
         - machines-io
-        # - bloodhound # BLOCKED derive and aeson-1.0
+        - bloodhound
 
     "Adam Bergmark <adam@bergmark.nl> @bergmark":
         - HUnit


### PR DESCRIPTION
I just uploaded bloodhound 0.12.0.0, which amongst other things, dropped the requirement of derive for tests and permits aeson 1.0.