### PR TITLE
Add libtool to debian-bootstrap.sh

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -95,6 +95,7 @@ apt-get install -y \
     libssl-dev \
     libsystemd-dev \
     libtagc0-dev \
+    libtool \
     libtre-dev \
     libudev-dev \
     libusb-1.0-0-dev \


### PR DESCRIPTION
I tried to install `secp256k1` in a `fpco/stack-build:lts-7.10` Docker image, but was greeted with this error:

```
$ cabal install secp256k1 -j1
Resolving dependencies...
cabal: Entering directory '/tmp/cabal-tmp-7220/secp256k1-0.4.6'
[1 of 1] Compiling Main             ( /tmp/cabal-tmp-7220/secp256k1-0.4.6/dist/dist-sandbox-dd682c91/setup/setup.hs, /tmp/cabal-tmp-7220/secp256k1-0.4.6/dist/dist-sandbox-dd682c91/setup/Main.o )
Linking /tmp/cabal-tmp-7220/secp256k1-0.4.6/dist/dist-sandbox-dd682c91/setup/setup ...
Can't exec "libtoolize": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 345, <GEN3> line 5.
autoreconf: failed to run libtoolize: No such file or directory
autoreconf: libtoolize is needed because this package uses Libtool
cabal: Leaving directory '/tmp/cabal-tmp-7220/secp256k1-0.4.6'
Failed to install secp256k1-0.4.6
cabal: Error: some packages failed to install:
secp256k1-0.4.6 failed during the configure step. The exception was:
ExitFailure 1
```

Installing `libtool` fixed the issue.