### PR TITLE
Add libsass-dev to debian-bootstrap.sh

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -88,6 +88,7 @@ apt-get install -y \
     libpango1.0-dev \
     libpcap0.8-dev \
     libpq-dev \
+    libsass-dev \
     libsdl2-dev \
     libsnappy-dev \
     libsndfile1-dev \


### PR DESCRIPTION
I tried to install `hsass` on a `fpco/stack-build:lts-7.10` Docker image, and was greeted with this error:

```
# cabal install hsass -j1
Resolving dependencies...
cabal: Entering directory '/tmp/cabal-tmp-8765/hsass-0.4.0'
Configuring hsass-0.4.0...
Building hsass-0.4.0...
Preprocessing library hsass-0.4.0...
[ 1 of 11] Compiling Text.Sass.Values ( Text/Sass/Values.hs, dist/build/Text/Sass/Values.o )
[ 2 of 11] Compiling Text.Sass.Utils  ( Text/Sass/Utils.hs, dist/build/Text/Sass/Utils.o )
[ 3 of 11] Compiling Text.Sass.Values.Internal ( Text/Sass/Values/Internal.hs, dist/build/Text/Sass/Values/Internal.o )
[ 4 of 11] Compiling Text.Sass.Values.Utils ( Text/Sass/Values/Utils.hs, dist/build/Text/Sass/Values/Utils.o )
[ 5 of 11] Compiling Text.Sass.Functions ( Text/Sass/Functions.hs, dist/build/Text/Sass/Functions.o )
[ 6 of 11] Compiling Text.Sass.Functions.Internal ( Text/Sass/Functions/Internal.hs, dist/build/Text/Sass/Functions/Internal.o )
[ 7 of 11] Compiling Text.Sass.Options ( Text/Sass/Options.hs, dist/build/Text/Sass/Options.o )
[ 8 of 11] Compiling Text.Sass.Options.Internal ( Text/Sass/Options/Internal.hs, dist/build/Text/Sass/Options/Internal.o )
[ 9 of 11] Compiling Text.Sass.Internal ( Text/Sass/Internal.hs, dist/build/Text/Sass/Internal.o )
[10 of 11] Compiling Text.Sass.Compilation ( Text/Sass/Compilation.hs, dist/build/Text/Sass/Compilation.o )
[11 of 11] Compiling Text.Sass        ( Text/Sass.hs, dist/build/Text/Sass.o )
/usr/bin/ld: error: cannot find -lsass
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
cabal: Leaving directory '/tmp/cabal-tmp-8765/hsass-0.4.0'
Failed to install hsass-0.4.0
cabal: Error: some packages failed to install:
hsass-0.4.0 failed during the building phase. The exception was:
ExitFailure 1
```

Installing `libsass-dev` fixed the issue.