### PR TITLE
Add oanda-rest-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2384,6 +2384,7 @@ packages:
         - protobuf-simple
 
     "David Reaver <johndreaver@gmail.com> @jdreaver":
+        - oanda-rest-api
         - stratosphere
 
     "Alexey Rodiontsev <alex.rodiontsev@gmail.com> @klappvisor":


### PR DESCRIPTION
I've had this package for a while, but only recently have all the dependencies been added to stackage (particularly `thyme`).