### PR TITLE
Re-enable some test suites

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2780,8 +2780,6 @@ skipped-tests:
     - Glob
     - HTTP
     - bindings-GLFW
-    - blaze-html
-    - blaze-markup
     - case-insensitive
     - darcs
     - exception-transformers
@@ -2790,15 +2788,12 @@ skipped-tests:
     - language-ecmascript
     - lifted-base
     - parsec
-    - psqueues
     - rank1dynamic
-    - stylish-haskell
     - threads
     - tz
     - tzdata
     - uuid
     - uuid-types
-    - websockets
     # # Other outdated dependencies
     - Cabal # QuickCheck 2.9
     - ReadArgs # https://github.com/rampion/ReadArgs/issues/8


### PR DESCRIPTION
These libraries have been bumped to allow `HUnit-1.5`.