### PR TITLE
add mnist-idx

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2625,6 +2625,8 @@ packages:
     "Tom Nielsen <tanielsen@gmail.com> @glutamate":
         - datasets
 
+    "Christof Schramm <christof.schramm@campus.lmu.de> @kryoxide"
+        - mnist-idx
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
The mnist-idx package is a handy parser for data from the [mnist database](http://yann.lecun.com/exdb/mnist/) of handwritten digits.