### PR TITLE
avers is compatible with hspec 2.3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2804,7 +2804,6 @@ skipped-tests:
     # # Other outdated dependencies
     - Cabal # QuickCheck 2.9
     - ReadArgs # https://github.com/rampion/ReadArgs/issues/8
-    - avers # hspec 2.3
     - bytestring-handle # QuickCheck 2.9
     - cases # https://github.com/nikita-volkov/cases/pull/3
     - chell # options & via chell-quickcheck


### PR DESCRIPTION
I created a new revision on hackage with an updated upper bound for hspec.