### PR TITLE
added vector-sized

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1492,6 +1492,7 @@ packages:
         - tagged-binary
         - typelits-witnesses
         - uncertain
+        - vector-sized
 
     "Ian Duncan <ian@iankduncan.com> @iand675":
         - feature-flags


### PR DESCRIPTION
as discussed in https://github.com/expipiplus1/vector-sized/pull/11 , i'm adding vector-sized as the designated stackage correspondent on behalf of the *vector-sized* maintainers.