### PR TITLE
Use newer version of haskell-gi-base

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2410,7 +2410,7 @@ packages:
         - gi-javascriptcore == 3.0.3
         - gi-webkit == 3.0.3
         - haskell-gi
-        - haskell-gi-base < 0.19
+        - haskell-gi-base
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":
         - directory-tree
@@ -3234,6 +3234,5 @@ tell-me-when-its-released:
 - point-octree-0.5.5.3 # re-enable test and then we can resolve https://github.com/fpco/lts-haskell/issues/27
 - wreq-0.4.1.0 # Try to re-enable lots of packages, (esp https://github.com/fpco/stackage/issues/2032) and the test-suite if https://github.com/bos/wreq/issues/53 is closed.
 - yarr-1.4.0.2 # Re-enable package https://github.com/fpco/stackage/issues/1876
-- haskell-gi-0.18 # Lift constraint on haskell-gi-base
 - terminal-progress-bar-0.1.1 # Unskip test suite
 - optparse-applicative-0.13.0.0 # Unskip test suite https://github.com/pcapriotti/optparse-applicative/issues/228


### PR DESCRIPTION
Needed for the latest versions of the autogenerated haskell-gi
bindings (gi-gtk, etc.), which are coming in a later commit.