### PR TITLE
Add 'line'

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2644,6 +2644,8 @@ packages:
     "Tom Nielsen <tanielsen@gmail.com> @glutamate":
         - datasets
 
+    "Hyunje Jun <me@noraesae.net> @noraesae":
+        - line
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
The 'line' package is Haskell SDK for the LINE API. FYI, LINE is a messaging platform. For the further details, please refer to the following links.

- https://line.me
- https://hackage.haskell.org/package/line

~~The version to be added is [`2.1.0.0`](https://hackage.haskell.org/package/line-2.1.0.0), though `./check` keeps checking `2.0.0.0` in my local env. If I missed something, please let me know.~~