### PR TITLE
add hip package. Enable repa, repa-io and repa-algorithms.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -651,9 +651,9 @@ packages:
         - versions
         - vectortiles
         - pipes-random
-        # - repa # BLOCKED QuickCheck < 2.9
-        # - repa-io # BLOCKED repa
-        # - repa-algorithms # BLOCKED repa
+        - repa
+        - repa-io
+        - repa-algorithms
         # GHC 8 - kanji
 
     "Ketil Malde @ketil-malde":
@@ -2650,6 +2650,9 @@ packages:
         - dmenu-pkill
         - dmenu-search
         - printcess
+
+    "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
+        - hip
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Restrictive QuickCheck upper bounds for repa were fixed in version [repa-3.4.1.2](http://hackage.haskell.org/package/repa-3.4.1.2)