### PR TITLE
Re-enable uri-templater

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1379,7 +1379,7 @@ packages:
         - bmp # Maintained by @benl23x5.
         # GHC 8 - ekg-statsd # Maintained by @tibbe.
         - flow
-        # via uri-templater - github-release
+        - github-release
         - gloss # Maintained by @benl23x5.
         - gloss-rendering # Maintained by @benl23x5.
         - gpolyline # Maintained by @fegu.
@@ -1515,8 +1515,8 @@ packages:
         - metrics
         - pipes-wai
         - serf
-        # 0.2.0.0 compilation failure - uri-templater
-        # via uri-templater - librato
+        - uri-templater
+        - librato
         # bounds - datadog
         # bounds - engine-io-growler
         # bounds - flowdock


### PR DESCRIPTION
Now that https://github.com/iand675/uri-templater/pull/3 has been merged, it should build with GHC 8. I also re-enabled any packages that were disabled because of a dependency on uri-templater. 