### PR TITLE
add OpenAL and ALUT packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -224,6 +224,10 @@ packages:
         - download
         - textlocal
 
+    "haskell-openal":
+        - OpenAL
+        - ALUT
+
     "haskell-opengl":
         - OpenGL
         - GLURaw
@@ -3191,9 +3195,13 @@ github-users:
         - meteficha
     analytics:
         - ekmett
+    haskell-openal:
+        - svenpanne
+        # - the-real-blackh
     haskell-opengl:
         - ekmett
         - svenpanne
+        # - dagit
         # - elliottt
         # - jmcarthur
     lambdabot:

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -45,6 +45,7 @@ apt-get install -y \
     git \
     libadns1-dev \
     libaio1 \
+    libalut-dev \
     libasound2-dev \
     libblas-dev \
     libbz2-dev \


### PR DESCRIPTION
This adds the ``OpenAL`` and ``ALUT`` packages from the ``haskell-openal`` organization to stackage. They need two native packages, ``libopenal-dev`` (already in ``debian-bootstrap.sh`` for some reason) and ``libalut-dev``.

Not really related, but nevertheless: In addition, ``dagit`` has been added as a potential maintainer for ``haskell-opengl`` packages, too, reflecting the status quo of the organization.