### PR TITLE
Add openjdk paths to dynamic linker system paths.

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -162,3 +162,7 @@ cd /tmp \
     && echo "/usr/local/lib" > /etc/ld.so.conf.d/usr-local.conf \
     && echo "/usr/lib/oracle/12.1/client64/lib" > /etc/ld.so.conf.d/oracle-client.conf \
     && ldconfig
+
+# Add JDK to system paths.
+echo "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/" > /etc/ld.so.conf.d/openjdk.conf \
+    && ldconfig


### PR DESCRIPTION
While stack succesfully builds jni, jvm even without this
change, it's a good idea to do this anyways. Not sure why Ubuntu
doesn't do it out-of-the-box. And it may help stackage-curator builds
(see #2139).

Note that sparkle builds fine on GHC 7.10, but not 8.0.1, because of
this GHC bug: https://ghc.haskell.org/trac/ghc/ticket/12082. We'll
have to wait until nightlies switch to 8.0.2 to add sparkle.