### PR TITLE
Remove bounds on gi-* packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2718,6 +2718,9 @@ packages:
         # https://github.com/fpco/stackage/issues/2163
         - cayley-client < 0.3.0
 
+        # https://github.com/yesodweb/shakespeare/issues/200
+        - shakespeare < 2.0.12
+
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3140,6 +3140,7 @@ expected-haddock-failures:
     # "Compilation" errors
     - MemoTrie # https://github.com/conal/MemoTrie/issues/10
     - metrics # https://github.com/iand675/metrics/issues/5
+    - text-generic-pretty # https://github.com/fpco/stackage/pull/2160
 
     # Haddock bugs
     - swagger2 # https://github.com/GetShopTV/swagger2/issues/66

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -723,7 +723,7 @@ packages:
         - hledger
         - hledger-lib
         - hledger-ui
-        # - hledger-web # https://github.com/fpco/stackage/issues/2164
+        - hledger-web
         - hledger-api
         # - shelltestrunner # bounds: Diff, HUnit
         - quickbench

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2418,21 +2418,18 @@ packages:
         - telegram-api
 
     "Iñaki García Etxebarria <garetxe@gmail.com> @garetxe":
-        # Pinned to versions not using custom-setup, since stack does
-        # not understand that syntax yet:
-        # https://github.com/commercialhaskell/stack/issues/2094
-        - gi-atk == 2.0.8
-        - gi-cairo == 1.0.8
-        - gi-gdk == 3.0.8
-        - gi-gdkpixbuf == 2.0.8
-        - gi-gio == 2.0.8
-        - gi-glib == 2.0.8
-        - gi-gobject == 2.0.8
-        - gi-gtk == 3.0.8
-        - gi-pango == 1.0.8
-        - gi-soup == 2.4.8
-        - gi-javascriptcore == 3.0.8
-        - gi-webkit == 3.0.8
+        - gi-atk
+        - gi-cairo
+        - gi-gdk
+        - gi-gdkpixbuf
+        - gi-gio
+        - gi-glib
+        - gi-gobject
+        - gi-gtk
+        - gi-pango
+        - gi-soup
+        - gi-javascriptcore == 3.0.*
+        - gi-webkit
         - haskell-gi
         - haskell-gi-base
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1,6 +1,10 @@
 ghc-major-version: "8.0"
 # Constraints for brand new builds
 packages:
+    "Joe M <joe9mail@gmail.com> @joe9":
+        - logger-thread
+        - text-generic-pretty
+
     "Li-yao Xia <lysxia@gmail.com> @Lysxia":
         - generic-random
         - postgresql-orm < 0


### PR DESCRIPTION
The latest versions in hackage should be buildable with both stack and
cabal new-build, so the versions do not need to be pinned anymore.