### PR TITLE
unblock tasty-tap, tasty-fail-fast

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1538,8 +1538,8 @@ packages:
         - uri-bytestring
         # - phash # Can't build on stackage server https://github.com/MichaelXavier/phash/issues/5
         - cron
-        # - tasty-tap # bounds: ghc, base
-        # - tasty-fail-fast # via: tasty-tap
+        - tasty-tap
+        - tasty-fail-fast
         - drifter
         - drifter-postgresql
 


### PR DESCRIPTION
tasty-tap-0.0.4 allows broader base. tasty-fail-fast builds with it as well, no new version required.