### PR TITLE
Enable the clash-ghc package again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1458,7 +1458,7 @@ packages:
         - clash-vhdl
         - clash-verilog
         - clash-systemverilog
-        # - clash-ghc # bounds: ghc
+        - clash-ghc
 
     "Athan Clark <athan.clark@gmail.com> @athanclark":
         - commutative


### PR DESCRIPTION
The newly released version 0.7, http://hackage.haskell.org/package/clash-ghc-0.7, compiles against GHC 8.0.2 and against all the latest versions of its dependencies.