### PR TITLE
Remove upper bound of hasql-transaction

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2774,9 +2774,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2213
         - memory < 0.14.1
 
-        # https://github.com/fpco/stackage/issues/2214
-        - hasql-transaction < 0.5
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
hasql-migration-0.1.3 builds with the new version. This fixes #2214.