### PR TITLE
Remove pugixml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -202,7 +202,6 @@ packages:
         - extra
         - bake
         - ghcid
-        - pugixml
         - hexml
 
     "Alan Zimmerman @alanz":


### PR DESCRIPTION
This library can segfault - see https://github.com/philopon/pugixml-hs/issues/5. It probably shouldn't be in Stackage, with the implied safety, until that is fixed.

Given my new hexml library, my desire for pugixml has also decreased.