### PR TITLE
Added skylighting (new dependency of pandoc).

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2198,6 +2198,7 @@ packages:
         - cmark
         - texmath
         - highlighting-kate
+        - skylighting
         - pandoc-types
         - zip-archive
         - doctemplates


### PR DESCRIPTION
skylighting is a syntax highlighting library that will
replace highlighting-kate for pandoc.  I have not removed
highlighting-kate, however, because it may be used by other packages,
but it should be considered deprecated.