### PR TITLE
add postgresql-typed, invertible, ztail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2857,6 +2857,12 @@ package-flags:
         ghc_7_7: false
         ghc_8_0: true
 
+    invertible:
+        TypeCompose: false
+        arrows: false
+        hlist: false
+        piso: false
+
 # end of package-flags
 
 # Special configure options for individual packages

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2712,6 +2712,11 @@ packages:
     "Mitsutoshi Aoe <maoe@foldr.in> @maoe":
         - viewprof
 
+    "Dylan Simon <dylan-stack@dylex.net> @dylex":
+        - postgresql-typed
+        - invertible
+        - ztail
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
All my own packages, checked against nightly-2017-01-26. Not sure if I handled the flags for invertible correctly: it has some optional dependencies not in stackage that can be disabled.