### PR TITLE
rm: allele as a maintainer - not enough time

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2532,10 +2532,6 @@ packages:
     "Christopher Wells <cwellsny@nycap.rr.com> @ExcalburZero":
         - pixelated-avatar-generator
 
-    "Allele Dev <allele.dev@gmail.com> @queertypes":
-        - freer
-        - wai-request-spec
-
     "Dominic Orchard <dom.orchard@gmail.com> @dorchard":
         - array-memoize
         # - camfort # https://github.com/fpco/stackage/issues/2232


### PR DESCRIPTION
I'm removing `freer` and `wai-request-spec` from stackage. I cannot honor the maintainer agreement between my current available time and funding.

Others are welcome to pick up those packages and fork them if they'd like to continue to use them.