### PR TITLE
glaze: workaround haddock crash by pasting splice explicitly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2719,7 +2719,7 @@ packages:
 
     "Louis Pan <louis@pan.me> @louispan":
         - alternators
-        # - glaze # Broken Haddocks https://github.com/louispan/glaze/issues/1
+        - glaze
         - glazier
         - glazier-pipes
         - l10n


### PR DESCRIPTION
Fixes louispan/glaze#1
Remove temporary block (54e81b970c290025a1b17af58e92d6dfdf0dac90) 