### PR TITLE
Re-added fasta and dependent libraries and applications.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1953,6 +1953,7 @@ packages:
         - clumpiness
         # - find-clumpiness # build failure against optparse-applicative https://github.com/GregorySchwartz/find-clumpiness/issues/1
         # - blosum # via fasta
+        - convert-annotation
 
     "Simon Marechal <bartavelle@gmail.com> @bartavelle":
         - compactmap

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1954,14 +1954,14 @@ packages:
         # - moesocks # https://github.com/nfjinjing/moesocks/issues/1
 
     "Gregory W. Schwartz <gregory.schwartz@drexel.edu> @GregorySchwartz":
-        # - fasta # via pipes-attoparsec
-        # - diversity # via fasta
-        # - modify-fasta # via fasta
+        - fasta
+        - diversity
+        - modify-fasta
         - tree-fun
         - random-tree
         - clumpiness
         # - find-clumpiness # build failure against optparse-applicative https://github.com/GregorySchwartz/find-clumpiness/issues/1
-        # - blosum # via fasta
+        - blosum
         - convert-annotation
 
     "Simon Marechal <bartavelle@gmail.com> @bartavelle":


### PR DESCRIPTION
`pipes-attoparsec` is added again, so fasta and friends should be fine now. Also added `convert-annotation` because I switched from `wreq` to `req`.