### PR TITLE
Add Gradle to the environment. Reenable sparkle.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1587,7 +1587,7 @@ packages:
         - inline-r
         - jni
         - jvm
-        # - sparkle # build failure, requires gradle
+        - sparkle
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -43,6 +43,7 @@ apt-get install -y \
     curl \
     freeglut3-dev \
     git \
+    gradle \
     libadns1-dev \
     libaio1 \
     libalut-dev \


### PR DESCRIPTION
sparkle requires GHC 8.0.2 to build, due to a bug in GHC 8.0.1.