### PR TITLE
Add scalpel-core

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1426,6 +1426,7 @@ packages:
         - prometheus-client
         - prometheus-metrics-ghc
         - scalpel
+        - scalpel-core
         - wai-middleware-prometheus
 
     "William Casarin <bill@casarin.me> @jb55":


### PR DESCRIPTION
This is the first step required to allow wikicfp-scraper to depend on scalpel v0.5.0 in #2269.