### PR TITLE
debian-bootstrap.sh: changes to support re-use in building 'fpco/stack-build' Docker images

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -27,10 +27,6 @@ add-apt-repository -y ppa:marutter/rrutter
 # Set the GHC version
 GHCVER=8.0.2
 
-# Get Stack
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
-echo 'deb http://download.fpcomplete.com/ubuntu xenial main'|tee /etc/apt/sources.list.d/fpco.list
-
 apt-get update
 apt-get install -y \
     build-essential \
@@ -122,12 +118,13 @@ apt-get install -y \
     r-base \
     r-base-dev \
     ruby-dev \
-    stack \
     wget \
     xclip \
     z3 \
     zip \
     zlib1g-dev
+
+curl -sSL https://get.haskellstack.org/ | sh
 
 # Put documentation where we expect it
 mv /opt/ghc/$GHCVER/share/doc/ghc-$GHCVER/ /opt/ghc/$GHCVER/share/doc/ghc

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -13,7 +13,6 @@
 set -exu
 
 mkdir /home/stackage -p
-locale-gen en_US.UTF-8
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
@@ -110,6 +109,7 @@ apt-get install -y \
     libzip-dev \
     libzmq3-dev \
     llvm-3.7 \
+    locales \
     m4 \
     nettle-dev \
     nodejs \
@@ -123,6 +123,8 @@ apt-get install -y \
     z3 \
     zip \
     zlib1g-dev
+
+locale-gen en_US.UTF-8
 
 curl -sSL https://get.haskellstack.org/ | sh
 


### PR DESCRIPTION
When starting from a bare system, `locale-gen` may not be installed, so this now installs the `locales` package before running `locale-gen`.

Also, this updates the `stack` installation to use get.haskellstack.org instead of the download.fpcomplete.com ubuntu package repository, which is being phased out.
