### PR TITLE
Reenable the hailgun and hailgun-simple libraries.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1867,8 +1867,8 @@ packages:
         - emailaddress
         - envelope
         - from-sum
-        # - hailgun # bounds: aeson
-        # - hailgun-simple # via hailgun
+        - hailgun
+        - hailgun-simple
         # - ig # bounds: http-conduit, transformers
         - natural-transformation
         - opaleye-trans


### PR DESCRIPTION
Hailgun was recently released to hackage, so it should now be compatible with the new version of aeson.