### PR TITLE
Add the yesod-markdown package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1878,6 +1878,7 @@ packages:
         - read-env-var
         - xml-html-qq
         - yahoo-finance-api
+        - yesod-markdown
 
     "Franklin Chen <franklinchen@franklinchen.com> @FranklinChen":
         - Ebnf2ps


### PR DESCRIPTION
This PR adds the [yesod-markdown](https://hackage.haskell.org/package/yesod-markdown) package under my name (@cdepillabout).

Heads up to @pbrisbin.  It [looks like](https://github.com/fpco/stackage/blob/master/build-constraints.yaml#L450) you currently have one package in stackage.  If you want `yesod-markdown` to go under your name instead of mine, please reply here to let me know.  I'll adjust the PR.