### PR TITLE
Add upper-bounds on packages that depend on xml-conduit-1.5.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2838,6 +2838,9 @@ packages:
 
         # https://github.com/fpco/stackage/issues/2312
         - xml-conduit < 1.5.0
+        - atom-conduit < 0.4.0.2
+        - imm < 1.1.0.1
+        - opml-conduit < 0.6.0.2
         - rss-conduit < 0.3.0.1
 # end of packages
 


### PR DESCRIPTION
Cf #2312

I'm in the process of updating `atom-conduit`, `opml-conduit` and `imm` to use `xml-conduit-1.5.0`.
In anticipation of this breaking change, let's add those upper-bounds.