### PR TITLE
re-enable git-annex in stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -672,7 +672,7 @@ packages:
         - opensource
 
     "Joey Hess <id@joeyh.name> @joeyh":
-        # - git-annex # bounds: bloomfilter, [...] # via: aws, esqueleto, [...] #
+        - git-annex
         # - github-backup # bounds: github
         - Win32-extras
         - concurrent-output


### PR DESCRIPTION
Now that esqueleto, aws, etc are fixed to work with ghc 8.x, git-annex builds again.