### PR TITLE
Remove invertible package flags

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2925,12 +2925,6 @@ package-flags:
         ghc_7_7: false
         ghc_8_0: true
 
-    invertible:
-        TypeCompose: false
-        arrows: false
-        hlist: false
-        piso: false
-
 # end of package-flags
 
 # Special configure options for individual packages


### PR DESCRIPTION
Remove the flag settings for invertible. These are now set to manual in 0.2.0.1, with arrows and piso disabled by default. My understading is stackage should still be able to pull in HList and TypeCompose, so trying that out here. Maybe related to #2305.