### PR TITLE
Remove invertible package flags

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2925,12 +2925,6 @@ package-flags:
         ghc_7_7: false
         ghc_8_0: true
 
-    invertible:
-        TypeCompose: false
-        arrows: false
-        hlist: false
-        piso: false
-
 # end of package-flags
 
 # Special configure options for individual packages


### PR DESCRIPTION
Retry #2321 to remove flags.  HList has been split out of invertible as of 0.2.0.2, and flags have been set manual as per dylex/invertible#2, so this dependency should now be okay. Hopefully TypeCompose will also build okay.