### PR TITLE
Add wai-middleware-auth to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2733,7 +2733,7 @@ packages:
         - printcess
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        []
+        - wai-middleware-auth
         # - hip # via repa: bounds: vector
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":


### PR DESCRIPTION
[wai-middleware-auth](https://hackage.haskell.org/package/wai-middleware-auth) on Hackage.