### PR TITLE
added raaz package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -671,6 +671,8 @@ packages:
         # - hopenpgp-tools # via ixset-typed: via safecopy: bounds: vector
         - opensource
 
+    "Piyush P Kurur <ppk@cse.iitk.ac.in> @piyush-kurur":
+        - raaz
     "Joey Hess <id@joeyh.name> @joeyh":
         # - git-annex # bounds: bloomfilter, [...] # via: aws, esqueleto, [...] #
         # - github-backup # bounds: github


### PR DESCRIPTION
I am sending this pull request to add raaz to stackage. Currently raaz
builds lts, nightly and debian-8. You can see the build status 
at https://travis-ci.org/raaz-crypto/raaz . The travis.yml is not the one
available with stackage as it is something that was part of raaz for quite some time
I guess this is fine (do let me know if you want this updated)


Being a crypto package one might want to build with some of the
flags set on. I am not sure what the policy of stack is towards it.

Please let me know if there is any problem