### PR TITLE
Add ‘path’ to Mark Karpov's packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2043,6 +2043,7 @@ packages:
         - flac
         - flac-picture
         - lame
+        - path
 
     # "Thomas Bereknyei <tomberek@gmail.com>":
         # - multiplate # bounds: transformers


### PR DESCRIPTION
I'm now a co-maintainer of `path` and I'll be checking and updating version boundaries of dependencies and stuff, so I'd like to be notified about issues related to `path`.