### PR TITLE
Update build-constraints.yml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -97,12 +97,12 @@ packages:
     "David Johnson <djohnson.m@gmail.com> @dmjio":
         - envy
         - s3-signer
-        # - google-translate # bounds: servant
-        # - hackernews # bounds: servant
-        # - ses-html # bounds: time 1.6
-        # - stripe-haskell # via: stripe-http-streams
-        # - stripe-http-streams # via: http-streams
-        # - stripe-core # bounds: aeson 1.0
+        - google-translate
+        - hackernews
+        - ses-html
+        - stripe-haskell
+        - stripe-http-streams
+        - stripe-core
 
     "Piotr Mlodawski @pmlodawski":
         - signal


### PR DESCRIPTION
Allow stripe, google-translate, hackernews, envy to be in lts8