### PR TITLE
Add vector tests back to Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3088,7 +3088,6 @@ skipped-tests:
     - state-plus # QuickCheck 2.9
     - system-filepath # QuickCheck 2.9 via chell-quickcheck
     - terminal-progress-bar # fixed on master, depends on older version of itself
-    - vector # https://github.com/haskell/vector/commit/31edb3fc51e76facc1e291f1e9e721663d91dbd8
 
     # Transitive outdated dependencies
     # These packages


### PR DESCRIPTION
As of `vector-0.12.0.1`, the test suite should be back in order.