### PR TITLE
Add proto-lens packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2868,6 +2868,15 @@ packages:
         - ziptastic-client
         - ziptastic-core
 
+    "Judah Jacobson <judah.jacobson@gmail.com> @judah":
+        - lens-labels
+        - proto-lens
+        - proto-lens-descriptors
+        - proto-lens-protoc
+        - proto-lens-combinators
+        - proto-lens-arbitrary
+        - proto-lens-optparse
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -117,6 +117,7 @@ apt-get install -y \
     nodejs \
     npm \
     openjdk-8-jdk \
+    protobuf-compiler \
     python-mpltoolkits.basemap \
     python3-matplotlib \
     python3-numpy \


### PR DESCRIPTION
Also adds the `protobuf-compiler` to `debian-bootstrap.sh` to get the
`/usr/bin/protoc` binary which `proto-lens-protoc` uses to generate bindings.