### PR TITLE
Re-enable postgresql-typed 0.5.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2955,9 +2955,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2393
         - HUnit < 1.6.0.0
 
-        # https://github.com/dylex/postgresql-typed/issues/4
-        - postgresql-typed < 0.5.0
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
I believe this problem started when postgresql-binary 0.12.1 was released (2 days ago).  (postgresql-typed 0.5.0 now has an upper bound constraint on postgresql-binary of 0.10.)  Earlier versions of postgresql-typed have the same issue, so I don't believe restricting 0.5.0 will fix the problem.  The options seem to be limiting postgresql-binary in stackage or removing postgresql-typed.  I've here removed postgresql-typed, but there's also an argument for restricting postgresql-binary < 0.12.

I'll also work on compatibility with the new postgresql-binary.  See dylex/postgresql-typed#4.