### PR TITLE
Reenable llvm-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2644,7 +2644,7 @@ packages:
 
     "Moritz Kiefer <moritz.kiefer@purelyfunctional.org> @cocreature":
         - lrucaching
-        # - llvm-hs # https://github.com/fpco/stackage/pull/2407
+        - llvm-hs
         - llvm-hs-pure
 
     "Thierry Bourrillon <thierry.bourrillon@fpinsight.com> @tbourrillon":


### PR DESCRIPTION
The build issues described in #2407 should be fixed in llvm-hs-4.0.1.0