### PR TITLE
FEATURE: Add package mnist-idx

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2898,6 +2898,9 @@ packages:
         - proto-lens-arbitrary
         - proto-lens-optparse
 
+    "Christof Schramm <christof.schramm@campus.lmu.de>":
+        - mnist-idx
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
Adds the mnist-idx package to stackage.

This package is useful for parsing the binary IDX format used in
the [MNIST-Database](http://yann.lecun.com/exdb/mnist/) of handwritten digits.