### PR TITLE
HDBC-mysql: fix package name capitalization

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2770,7 +2770,7 @@ packages:
         - pqueue
 
     "Ryan Mulligan <ryan@ryantm.com> @ryantm":
-      - hdbc-mysql
+      - HDBC-mysql
 
     "Tony Day <tonyday567@gmail.com> @tonyday567":
         []


### PR DESCRIPTION
Hello.

I noticed https://www.stackage.org/package/HDBC-mysql doesn't list this package in any snapshots, but I've had it in the build-constraints.yaml file for a long time. I'm guessing it is because the capitalization was wrong, but maybe someone with more knowledge of Stackage can confirm that, or tell me why it's not in any snapshot.

Ryan

ref: https://github.com/ryantm/hdbc-mysql/issues/24