### PR TITLE
Re-enable wai-middleware-auth

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2848,8 +2848,7 @@ packages:
         - printcess
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        []
-        # - wai-middleware-auth # https://github.com/fpco/wai-middleware-auth/issues/3
+        - wai-middleware-auth
         # - hip # via repa: bounds: vector
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":


### PR DESCRIPTION
Compatibility issue with hoauth2 >= 1.0.0 is now fixed.