### PR TITLE
Add chaselev-deque, monad-par, and friends

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1861,7 +1861,12 @@ packages:
         - type-level-numbers
 
     "Ryan Scott <ryan.gl.scott@gmail.com> @RyanGlScott":
+        - abstract-deque
+        - abstract-deque-tests
+        - abstract-par
+        - atomic-primops
         - base-orphans
+        - chaselev-deque
         - code-page
         - deriving-compat
         - echo
@@ -1871,6 +1876,8 @@ packages:
         - keycode
         - lift-generics
         - mintty
+        - monad-par
+        - monad-par-extras
         - mtl-compat
         - proxied
         - text-show


### PR DESCRIPTION
I'm adding these packages under my name with the permission of @rrnewton (the author). See also https://github.com/rrnewton/haskell-lockfree/issues/63.