### PR TITLE
Add "weeder" package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -295,7 +295,7 @@ packages:
         - timelens
         - non-empty-sequence
 
-    "Neil Mitchell @ndmitchell":
+    "Neil Mitchell <ndmitchell@gmail.com> @ndmitchell":
         - hlint
         - hoogle
         - shake
@@ -310,6 +310,7 @@ packages:
         - bake
         - ghcid
         - hexml
+        - weeder
 
     "Alan Zimmerman @alanz":
         - hjsmin


### PR DESCRIPTION
This adds the weeder package to stackage. Note that the weeder package is an executable only, without any associated libraries. I assume that's acceptable for Stackage, but the MAINTAINERS agreement doesn't say either way (which might be worth fixing).