### PR TITLE
Reenable nvim-hs nvim-hs-contrib nvim-hs-ghcid

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3017,10 +3017,9 @@ packages:
         - uri-bytestring-aeson
 
     "Sebastian Witte <woozletoff@gmail.com> @saep":
-        []
-        # - nvim-hs # build failure https://github.com/fpco/stackage/pull/2457
-        # - nvim-hs-contrib # per nvim-hs
-        # - nvim-hs-ghcid # per nvim-hs
+        - nvim-hs
+        - nvim-hs-contrib
+        - nvim-hs-ghcid
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
I adjusted the tests to not require the neovim executable anymore. I tested the distribution tarball instead of the git repository, so I'm confident it will work now.