### PR TITLE
Enable twitter-conduit again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2217,7 +2217,7 @@ packages:
 
     "Takahiro Himura <himuratk421@gmail.com> @thimura":
         - lens-regex
-        # - twitter-conduit # bounds: http-conduit 2.2 # via: twitter-types, twitter-types-lens
+        - twitter-conduit
         - twitter-types
         - twitter-types-lens
 


### PR DESCRIPTION
Version 0.2.2 of twitter-conduit has now working dependencies to http-conduit and http-client