### PR TITLE
Exclude Mark Karpov from ‘stackbuilders’ group

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2169,6 +2169,7 @@ packages:
         - lame
         - path
         - forma
+        - stache
 
     # "Thomas Bereknyei <tomberek@gmail.com>":
         # - multiplate # bounds: transformers
@@ -3902,7 +3903,6 @@ github-users:
         - sestrella
         - jsl
         - jsantos17
-        - mrkkrp
     scotty-web:
         - RyanGlScott
         - xich


### PR DESCRIPTION
Soon I'll stop working for Stack Builders thus I remove myself from the `stackbuilders` group. I still would like to be notified about `stache`-related issues, so I add that under my own name (will this work? are these names from Hackage or repo names from GitHub?).