### PR TITLE
Add eventful packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2619,6 +2619,13 @@ packages:
         - protobuf-simple
 
     "David Reaver <johndreaver@gmail.com> @jdreaver":
+        - eventful-core
+        - eventful-dynamodb
+        - eventful-memory
+        - eventful-postgresql
+        - eventful-sql-common
+        - eventful-sqlite
+        - eventful-test-helpers
         - oanda-rest-api
         - stratosphere
 
@@ -3460,6 +3467,8 @@ expected-test-failures:
     - dns # https://github.com/kazu-yamamoto/dns/issues/29
     - drifter-postgresql # PostgreSQL
     - etcd # etcd https://github.com/fpco/stackage/issues/811
+    - eventful-dynamodb
+    - eventful-postgresql
     - eventstore # Event Store
     - fb # Facebook app
     - ghc-imported-from # depends on haddocks being generated first https://github.com/fpco/stackage/pull/1315


### PR DESCRIPTION
This PR adds all the [`eventful`](https://github.com/jdreaver/eventful) packages to stackage. I disabled the tests for the DynamoDB and PostgreSQL backend since those require running servers. The SQLite backend should be find since it just uses an in-memory SQLite connection.