### PR TITLE
Make the ersatz tests pass

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3398,9 +3398,6 @@ skipped-tests:
     # criterion
     - store
 
-    # requires custom setup?
-    - ersatz # https://github.com/fpco/stackage/issues/2508
-
 # end of skipped-tests
 
 # Tests which we should build and run, but which are expected to fail. We

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -117,6 +117,7 @@ apt-get install -y \
     llvm-3.7 \
     locales \
     m4 \
+    minisat \
     mono-mcs \
     nettle-dev \
     nodejs \


### PR DESCRIPTION
The `ersatz` tests should pass as long as `minisat` is installed.

Fixes https://github.com/fpco/stackage/issues/2508.