### PR TITLE
Remove upper bound on lens with active-0.2.0.13 (#2496)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3148,9 +3148,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2464
         - traverse-with-class < 1.0.0.0
 
-        # https://github.com/diagrams/active/issues/20
-        - lens < 4.15.2
-
         # https://github.com/fpco/stackage/issues/2477
         - intervals < 0.8
 
@@ -4008,7 +4005,6 @@ tell-me-when-its-released:
 - req-0.2.0 # Remove from expected-test-failures https://github.com/mrkkrp/req/issues/14#issuecomment-287562784
 - vivid-0.2.0.5 # Re-enable package (disabed per MonadRandom < 0.5) https://github.com/fpco/stackage/issues/2180
 - lens-4.15.2 # Test failures in lens-4.15.1 https://github.com/fpco/stackage/issues/2496
-- active-0.2.0.12 # Will likely contain fix for the lens-4.15.2 https://github.com/fpco/stackage/issues/2496
 
 # Packages which should be hidden after registering, to avoid module name
 # conflicts. This is intended for at least two use cases:


### PR DESCRIPTION
I have also removed active-0.2.0.12 watchpoint.

---

Despite the release of active-0.2.0.13 (which I have unpacked) my attempts to run stackage curator locally gives me:
```
lens-4.15.2 (Edward Kmett <ekmett@gmail.com> @ekmett) is out of bounds for:
- [ ] active-0.2.0.12 (>=4.0 && < 4.15.2). Brent Yorgey <byorgey@gmail.com> @byorgey. @bergey @byorgey @fryguybob @jeffreyrosenbluth. Used by: library, test-suite
````

So I am raising a PR.