### PR TITLE
Reenable yesod-job-queue

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2589,7 +2589,7 @@ packages:
 
     "Daishi Nakajima <nakaji.dayo@gmail.com> @nakaji_dayo":
         - api-field-json-th
-        # - yesod-job-queue # compilation failure: nakaji-dayo/yesod-job-queue/issues/12
+        - yesod-job-queue
 
     # "Braden Walters <vc@braden-walters.info> @meoblast001":
         # - hakyll-sass # compilation failure


### PR DESCRIPTION
Last time it failed nightly build.
https://github.com/nakaji-dayo/yesod-job-queue/issues/12

I fixed it in https://github.com/nakaji-dayo/yesod-job-queue/pull/13/commits/3072e5f0f91eb7e1d0392e04e7a421d3dddef486 .
And, released it as 0.3.0.4 .