### PR TITLE
Reenable and fix the tensorflow-* packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3021,10 +3021,10 @@ packages:
         - proto-lens-combinators
         - proto-lens-arbitrary
         - proto-lens-optparse
-        # - tensorflow          # blocked on C library
-        # - tensorflow-core-ops # blocked on C library
+        - tensorflow
+        - tensorflow-core-ops
         - tensorflow-opgen
-        # - tensorflow-ops      # blocked on C library
+        - tensorflow-ops
         - tensorflow-proto
         - tensorflow-test
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -123,7 +123,6 @@ apt-get install -y \
     nodejs \
     npm \
     openjdk-8-jdk \
-    protobuf-compiler \
     python-mpltoolkits.basemap \
     python3-matplotlib \
     python3-numpy \
@@ -191,9 +190,15 @@ wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get install -y llvm-4.0
 
+# Install version 3 of the protobuf compiler.  (The `protobuf-compiler` package only
+# supports version 2.)
+curl -OL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip \
+  && sudo unzip -o protoc-3.3.0-linux-x86_64.zip -d /usr bin/protoc \
+  && rm -f protoc-3.3.0-linux-x84_64.zip
+
 # Install the TensorFlow C API.
 curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.1.0.tar.gz > libtensorflow.tar.gz \
-    && sudo tar zxf libtensorflow.tar.gz -C /usr/local \
+    && sudo tar zxf libtensorflow.tar.gz -C /usr \
     && rm libtensorflow.tar.gz \
     && ldconfig
 


### PR DESCRIPTION
Previously we installed libtensorflow into /usr/local/lib which wasn't in the
search path.  Moving it to /usr/lib fixed the problem.

Also changed the script to manually install protoc v3.3.0.  The default
version of `protobuf-compiler` in Xenial is v2.6.1 which is too old to build
`tensorflow-proto`.

Verified by building the docker image locally and then running
`stack install tensorflow tensorflow-ops ...` from within it.