### PR TITLE
Add sum-type-boilerplate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2641,6 +2641,7 @@ packages:
         - eventful-test-helpers
         - oanda-rest-api
         - stratosphere
+        - sum-type-boilerplate
 
     "Alexey Rodiontsev <alex.rodiontsev@gmail.com> @klappvisor":
         []


### PR DESCRIPTION
This adds my new [`sum-type-boilerplate`](https://github.com/jdreaver/sum-type-boilerplate) package. Note that I only recently uploaded it to Hackage as of a few minutes ago. I'm not sure if that is relevant to your Hackage indexing functionality.