### PR TITLE
Enable prettyprinter-compat-wl-pprint-ansi again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2353,7 +2353,7 @@ packages:
         - prettyprinter
         - prettyprinter-ansi-terminal
         - prettyprinter-compat-wl-pprint
-        #- prettyprinter-compat-ansi-wl-pprint # https://github.com/fpco/stackage/pull/2548
+        - prettyprinter-compat-ansi-wl-pprint
         - prettyprinter-compat-annotated-wl-pprint
 
     "Jeremy Shaw <jeremy@n-heptane.com> @stepcut":


### PR DESCRIPTION
This package was disabled because of package version shenanigans (error on my end) that should now be fixed. See https://github.com/quchen/prettyprinter/issues/24 for the library ticket, and https://github.com/fpco/stackage/pull/2548 for the Stackage one.