### PR TITLE
Add the `proto-lens-protobuf-types` pacakge.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3044,10 +3044,11 @@ packages:
         - proto-lens-combinators
         - proto-lens-arbitrary
         - proto-lens-optparse
-        - tensorflow          # https://github.com/fpco/stackage/issues/2527
-        - tensorflow-core-ops # https://github.com/fpco/stackage/issues/2527
+        - proto-lens-protobuf-types
+        - tensorflow
+        - tensorflow-core-ops
         - tensorflow-opgen
-        - tensorflow-ops      # https://github.com/fpco/stackage/issues/2527
+        - tensorflow-ops
         - tensorflow-proto
         - tensorflow-test
 


### PR DESCRIPTION
It has been released on Hackage.  It will also eventually be a dependency
for the next release of the `tensorflow-proto` package.

Also removed old comments referencing a closed issue.