### PR TITLE
Re-enable several ekmett packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -452,16 +452,16 @@ packages:
     "Edward Kmett <ekmett@gmail.com> @ekmett":
         - ad
         - adjunctions
-        # - approximate # bounds: binary, comonad, pointed
+        - approximate
         - bifunctors
         - bits
-        # - bound # bounds: binary, comonad, doctest, transformers, vector
+        - bound
         - bytes
         - charset
         - comonad
         - comonads-fd
         - comonad-transformers
-        # - compensated # bounds: binary, comonad, generic-deriving, safecopy
+        - compensated
         # - compressed # bounds: comonad, pointed
         - concurrent-supply
         - constraints
@@ -475,6 +475,7 @@ packages:
         - graphs
         - groupoids
         - heaps
+        - hyperloglog
         - hyphenation
         - integration
         - intervals
@@ -483,7 +484,7 @@ packages:
         - lens
         - linear
         - linear-accelerate
-        # - log-domain # via safecopy: bounds: vector
+        - log-domain
         - machines
         - monadic-arrays
         - monad-products
@@ -518,7 +519,6 @@ packages:
         - gl
         - lens-aeson
         - zlib-lens
-        # - hyperloglog # bounds: approximate, binary, comonad
 
     "Andrew Farmer <afarmer@ittc.ku.edu> @xich":
         - scotty


### PR DESCRIPTION
I've gone through and released new versions of several packages with up-to-date dependencies, so they can be put back on Stackage.