### PR TITLE
Add opencv and opencv-extra

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1,6 +1,10 @@
 ghc-major-version: "8.0"
 # Constraints for brand new builds
 packages:
+    "Bas van Dijk <v.dijk.bas@gmail.com> @basvandijk":
+        - opencv
+        - opencv-extra
+
     "Pasqualino Assini <tittoassini@gmail.com> @tittoassini":
         - zm
         - flat

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -207,3 +207,53 @@ curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-l
 #apt-add-repository multiverse \
 #    && apt-get update \
 #    && apt-get install -y libfdk-aac-dev
+
+
+################################################################################
+# Install opencv.
+
+OPENCV_VERSION="3.2.0"
+
+apt-get install -y \
+    cmake \
+    pkg-config \
+    libjpeg-dev \
+    libtiff5-dev \
+    libjasper-dev \
+    libpng12-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libxvidcore-dev \
+    libx264-dev \
+    libv4l-dev \
+    liblapacke-dev \
+    libgtk-3-dev \
+    libopenblas-dev \
+    libhdf5-dev \
+    libtesseract-dev \
+    libleptonica-dev \
+    python3-dev \
+    gfortran
+
+# Make a new directory
+rm -rf /tmp/opencv-build
+mkdir /tmp/opencv-build
+cd /tmp/opencv-build
+
+# Download OpenCV
+curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar xz
+curl -L https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.tar.gz | tar xz
+
+cd opencv-${OPENCV_VERSION}
+mkdir build
+cd build
+cmake -D CMAKE_BUILD_TYPE=RELEASE \
+      -D CMAKE_INSTALL_PREFIX=/usr/local \
+      -D OPENCV_EXTRA_MODULES_PATH=/tmp/opencv-build/opencv_contrib-${OPENCV_VERSION}/modules
+
+make -j
+
+make install
+
+################################################################################


### PR DESCRIPTION
This adds the [opencv](http://hackage.haskell.org/package/opencv) and [opencv-extra](http://hackage.haskell.org/package/opencv-extra) packages.

I haven't tested the OpenCV installation in the `debian-bootstrap.sh` yet. How can I do that?