### PR TITLE
Re-added find-clumpiness.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2153,7 +2153,7 @@ packages:
         - tree-fun
         - random-tree
         - clumpiness
-        # - find-clumpiness # build failure against optparse-applicative https://github.com/GregorySchwartz/find-clumpiness/issues/1
+        - find-clumpiness
         - blosum
         # - convert-annotation # via cassava: bounds: vector
         - rank-product


### PR DESCRIPTION
I have added submodules of the dependencies so I could relax the bounds. It builds against lts-8.20 so I assume the optparse-applicative issues are resolved.