### PR TITLE
Ignore revisions for `hjsonpointer`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4039,5 +4039,6 @@ hide:
 # Experimental: packages where Hackage cabal file revisions should be ignored.
 # Always use the cabal file shipped with the sdist tarball instead.
 no-revisions:
+- hjsonpointer
 - tls
 - mime-mail


### PR DESCRIPTION
I'm experimenting with the new `pvp-bounds: upper-revision` stack.yml
feature.