### PR TITLE
Upgrade `errors', Close #2378

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1626,11 +1626,11 @@ packages:
         - ghc-typelits-knownnat
         - ghc-typelits-natnormalise
         - clash-prelude
-        - clash-lib
-        - clash-vhdl
-        - clash-verilog
-        - clash-systemverilog
-        - clash-ghc
+        # - clash-lib # bounds: errors
+        # - clash-vhdl # bounds: errors
+        # - clash-verilog # bounds: errors
+        # - clash-systemverilog # bounds: errors
+        # - clash-ghc # bounds: errors
 
     "Athan Clark <athan.clark@gmail.com> @athanclark":
         - commutative
@@ -3169,9 +3169,6 @@ packages:
         - tcp-streams < 1.0.0.0
         - tcp-streams-openssl < 1.0.0.0
         - mysql-haskell < 0.8.1.0
-
-        # https://github.com/fpco/stackage/issues/2378
-        - errors < 2.2.0
 
         # https://github.com/fpco/stackage/issues/2393
         - HUnit < 1.6.0.0


### PR DESCRIPTION
Affected maintainers: @christiaanb 

I'll upgrade errors in a few days, so the clash packages will be disabled unless they've been updated by then.
