### PR TITLE
added vector-mmap

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2483,6 +2483,7 @@ packages:
 
     "Florian Hofmann fho@f12n.de @fhaust":
         - vector-split
+        - vector-mmap
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Version 0.0.3 is on hackage and tested on travis:

http://hackage.haskell.org/package/vector-mmap
https://travis-ci.org/fhaust/vector-mmap/builds

Publishing under my name with agreement of the original author: https://github.com/copumpkin/vector-mmap/pull/4