### PR TITLE
re-enable h2c and bno055-haskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3155,9 +3155,8 @@ packages:
         - mltool
 
     "Edward Amsden <edwardamsden@gmail.com> @eamsden": []
-        # - h2c # freshly added package is missing headers:
-                # https://github.com/fpco/stackage/issues/2642
-        # - bno055-haskell
+        - h2c
+        - bno055-haskell
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3154,7 +3154,7 @@ packages:
         - astro
         - mltool
 
-    "Edward Amsden <edwardamsden@gmail.com> @eamsden": []
+    "Edward Amsden <edwardamsden@gmail.com> @eamsden":
         - h2c
         - bno055-haskell
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -70,6 +70,7 @@ apt-get install -y \
     libgtk2.0-dev \
     libgtksourceview-3.0-dev \
     libhidapi-dev \
+    libi2c-dev \
     libicu-dev \
     libimlib2-dev \
     libjack-jackd2-dev \


### PR DESCRIPTION
Also adds libi2c-dev to debian-bootstrap.sh, so h2c has the proper header file available to build

This should fix #2642 