### PR TITLE
First step to GHC 8.2.1: drop upper bounds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2980,7 +2980,8 @@ packages:
         # - hip # via repa: bounds: vector
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
-        - hledger-iadd
+        []
+        # - hledger-iadd # bounds: hledger-lib
 
     "Roy Levien <royl@aldaron.com> @orome":
         - crypto-enigma
@@ -3219,14 +3220,6 @@ packages:
 
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
-
-
-        # https://github.com/fpco/stackage/issues/2628
-        - hledger-lib < 1.3
-        - hledger < 1.3
-        - hledger-api < 1.3
-        - hledger-ui < 1.3
-        - hledger-web < 1.3
 
         # ghc-8.2.1
         # https://github.com/fpco/stackage/issues/2659

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3197,7 +3197,7 @@ packages:
 
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/2127
-        - leapseconds-announced < 2017.0.0.1
+        - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
 
         # https://github.com/fpco/stackage/issues/2329
         - network-transport < 0.5

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2042,7 +2042,7 @@ packages:
         - attoparsec-binary
 
     "Brandon Martin <brandon@codedmart.com> @codedmart":
-        - engine-io-wai
+        # - engine-io-wai # bounds websockets
         - rethinkdb
 
     "Michael Walker <mike@barrucadu.co.uk> @barrucadu":
@@ -2987,7 +2987,7 @@ packages:
         - haskell-tools-rewrite
         - haskell-tools-prettyprint
         - haskell-tools-refactor
-        - haskell-tools-demo
+        # - haskell-tools-demo # bounds: websockets
         - haskell-tools-cli
         - haskell-tools-daemon
         - haskell-tools-debug
@@ -3202,12 +3202,6 @@ packages:
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
-
-        # https://github.com/fpco/stackage/issues/2451
-        - websockets < 0.11.0.0
-        - servant-subscriber < 0.6.0.1
-        - websockets-simple < 0.0.2.1
-        - websockets-rpc < 0.4.1
 
         # https://github.com/fpco/stackage/issues/2528
         - concurrent-output < 1.10.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2660,7 +2660,7 @@ packages:
 
     "Daishi Nakajima <nakaji.dayo@gmail.com> @nakaji_dayo":
         - api-field-json-th
-        - yesod-job-queue
+        # - yesod-job-queue # bounds cron
 
     # "Braden Walters <vc@braden-walters.info> @meoblast001":
         # - hakyll-sass # compilation failure
@@ -3224,9 +3224,6 @@ packages:
         - hledger-api < 1.3
         - hledger-ui < 1.3
         - hledger-web < 1.3
-
-        # https://github.com/fpco/stackage/issues/2646
-        - cron < 0.6
 
         # https://github.com/fpco/stackage/issues/2656
         - happstack-server < 7.5.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1042,7 +1042,7 @@ packages:
        - users-test
        - validate-input
        - ignore
-       - elm-bridge
+       # - elm-bridge # bounds: aeson
        # digestive-bootstrap # via: digestive-functors, digestive-functors-blaze
        - blaze-bootstrap
        - dataurl
@@ -1137,7 +1137,7 @@ packages:
         - cabal-rpm
         - stackage-query
         # - cabal-sort # BLOCKED directory 1.3
-        - idris
+        # - idris # bounds aeson
         - libffi
         - xmonad-contrib
         - shelly
@@ -2372,7 +2372,7 @@ packages:
         - pusher-http-haskell
 
     "Yorick Laupa yo.eight@gmail.com @YoEight":
-        - eventstore
+        # - eventstore # bounds: aeson
         - dotnet-timespan
 
     "Sebastian Dröge slomo@coaxion.net @sdroege":
@@ -2552,10 +2552,10 @@ packages:
         - string-conv
         - rng-utils
         - rotating-log
-        - ua-parser
+        # - ua-parser # bounds aeson
         - hs-GeoIP
         - retry
-        - katip
+        # - katip # bounds aeson
         # - katip-elasticsearch # via bloodhound: bounds: vector
 
     "Sid Kapur sidharthkapur1@gmail.com @sid-kap":
@@ -3206,9 +3206,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2393
         - HUnit < 1.6.0.0
 
-        # https://github.com/fpco/stackage/issues/2449
-        - aeson < 1.2.0.0
-
         # https://github.com/fpco/stackage/issues/2451
         - websockets < 0.11.0.0
         - servant-subscriber < 0.6.0.1
@@ -3594,6 +3591,7 @@ skipped-tests:
     - wai-middleware-rollbar
     - websockets
     - path
+    - aeson
 
 # end of skipped-tests
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2636,8 +2636,9 @@ packages:
         - papillon
 
     "Jan Gerlinger <git@jangerlinger.de> @JanGe":
-        - irc-dcc
-        - xdcc
+        []
+        # - irc-dcc # bounds: path
+        # - xdcc # bounds: path
 
     "John Ky newhoggy@gmail.com @newhoggy":
         - hw-bits
@@ -3234,9 +3235,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/2569
         - optparse-applicative < 0.14
-
-        # https://github.com/fpco/stackage/issues/2583
-        - path < 0.6
 
         # https://github.com/fpco/stackage/issues/2584
         - tasty-quickcheck < 0.9

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -373,9 +373,9 @@ packages:
         - blaze-html
         - blaze-markup
         - cabal-dependency-licenses
-        - hakyll
+        # - hakyll # bounds: skylighting
         - stylish-haskell
-        - patat
+        # - patat # bounds: skylighting
         - profiteur
         - psqueues
         - websockets
@@ -576,8 +576,8 @@ packages:
 
     "Brent Yorgey <byorgey@gmail.com> @byorgey":
         - active
-        - BlogLiterately
-        - BlogLiterately-diagrams
+        # - BlogLiterately # bounds: skylighting
+        # - BlogLiterately-diagrams # bounds: skylighting
         - diagrams
         - diagrams-builder
         # - diagrams-haddock # BLOCKED directory 1.3 via cautious-file
@@ -1673,8 +1673,8 @@ packages:
         - poly-arity
         - urlpath
         - wai-transformers
-        - wai-middleware-content-type
-        - wai-middleware-verbs
+        # - wai-middleware-content-type # bounds: skylighting
+        # - wai-middleware-verbs # bounds: skylighting
         - websockets-rpc
         - webpage
         - composition-extra
@@ -2076,7 +2076,7 @@ packages:
         - xml-html-qq
         - xml-indexed-cursor
         - yahoo-finance-api
-        - yesod-markdown
+        # - yesod-markdown # bounds: skylighting
 
     "Franklin Chen <franklinchen@franklinchen.com> @FranklinChen":
         - Ebnf2ps
@@ -2532,8 +2532,8 @@ packages:
         - pandoc-types < 1.19 # Accidental upload, see: https://github.com/fpco/stackage/issues/2223
         - zip-archive
         - doctemplates
-        - pandoc
-        - pandoc-citeproc
+        # - pandoc # bounds: skylighting
+        # - pandoc-citeproc # bounds: skylighting
 
     "Karun Ramakrishnan <karun012@gmail.com> @karun012":
         - doctest-discover
@@ -2541,7 +2541,7 @@ packages:
     "Elie Genard <elaye.github.io@gmail.com> @eliegenard":
         - turtle-options
         - mushu
-        - hakyll-favicon
+        # - hakyll-favicon # bounds: skylighting
 
     # "Ruey-Lin Hsu <petercommand@gmail.com> @petercommand":
         # - MASMGen # bounds: ghc, base
@@ -3198,9 +3198,6 @@ packages:
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1
-
-        # https://github.com/fpco/stackage/issues/2317
-        - skylighting < 0.2
 
         # https://github.com/fpco/stackage/issues/2329
         - network-transport < 0.5

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -35,7 +35,8 @@ packages:
         - clr-inline  # possibly nondeterministic failures, see https://github.com/fpco/stackage/issues/2510
 
     "Joshua Koike <jkoike2013@gmail.com> @jano017":
-        - discord-hs
+        []
+        # - discord-hs # bouns: req
 
     "Roman Gonzalez <romanandreg@gmail.com> @roman":
         - etc
@@ -3270,10 +3271,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2587
         - extra < 1.6
 
-        # https://github.com/fpco/stackage/issues/2594
-        - req < 0.3.0 # also remove from expected-test-failure
-        - req-conduit < 0.2.0 # because of above
-
         # https://github.com/fpco/stackage/issues/2595
         - cassava < 0.5.0.0
         - cassava-conduit < 0.4.0.0 # because of above and #2586
@@ -3773,7 +3770,6 @@ expected-test-failures:
     - ghcid # Weird conflicts with sandboxingistributed/distributed-process-supervisor/issues/1
     - haskell-docs # GHC bug
     - rattletrap # OOM? https://github.com/fpco/stackage/issues/2232
-    - req # https://github.com/mrkkrp/req/issues/14#issuecomment-287562784
     - servant # https://github.com/haskell-servant/servant/issues/698
     - snap-core # https://github.com/snapframework/snap-core/issues/26
     - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3216,10 +3216,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2569
         - optparse-applicative < 0.14
 
-        # https://github.com/fpco/stackage/issues/2584
-        - tasty-quickcheck < 0.9
-        - arithmoi < 0.5.0.1
-
         # https://github.com/fpco/stackage/issues/2587
         - extra < 1.6
 
@@ -3560,7 +3556,6 @@ skipped-tests:
     - teardown # https://github.com/roman/Haskell-teardown/issues/1
 
     # QuickCheck 2.10
-    - arithmoi
     - blaze-html
     - blaze-markup
     - cassava-conduit
@@ -3579,6 +3574,14 @@ skipped-tests:
 
     # HUnit 1.6
     - terminal-progress-bar
+
+    # tasty-quickcheck 0.9
+    - binary-parser
+    - cryptohash-sha512
+    - diagrams-solve
+    - tar
+    - vector-builder
+    - zlib
 
 # end of skipped-tests
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3349,6 +3349,9 @@ package-flags:
         time_1_6_and_1_7: true
         time_pre_1_6: false
 
+    mintty:
+        win32-2-5: false
+
 # end of package-flags
 
 # Special configure options for individual packages

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -893,7 +893,7 @@ packages:
         - uri-encode
 
     "Simon Michael <simon@joyful.com> @simonmichael":
-        - darcs
+        # - darcs # bounds: graphviz < 2999.19
         - hledger
         - hledger-lib
         - hledger-ui
@@ -3213,9 +3213,6 @@ packages:
         - servant-subscriber < 0.6.0.1
         - websockets-simple < 0.0.2.1
         - websockets-rpc < 0.4.1
-
-        # https://github.com/fpco/stackage/issues/2487
-        - graphviz < 2999.19
 
         # https://github.com/fpco/stackage/issues/2528
         - concurrent-output < 1.10.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1107,7 +1107,7 @@ packages:
     "Alexandr Ruchkin <voidex@live.com> @mvoidex":
         - hdocs
         - hformat
-        - hsdev
+        # - hsdev # bounds: mmorph
         - simple-log
         - text-region
 
@@ -1627,7 +1627,7 @@ packages:
         - pipes-mongodb # via mongoDB
         - servant-elm
         - skeletons
-        - streaming-wai
+        # - streaming-wai # bounds: mmorph
 
     # "Smirnov Alexey <chemistmail@gmail.com> @chemist":
         # - snmp # bounds: ghc, base
@@ -1715,9 +1715,9 @@ packages:
         - lens-simple
         - lens-family-core
         - lens-family
-        - streaming
-        - streaming-bytestring
-        - streaming-utils
+        # - streaming # bounds: mmorph
+        # - streaming-bytestring # bounds: mmorph
+        # - streaming-utils # bounds: mmorph
 
     "Justin Le <justin@jle.im> @mstksg":
         - auto
@@ -1781,8 +1781,8 @@ packages:
         - inline-r
         - jni
         - jvm
-        - sparkle
-        - streaming-binary
+        # - sparkle # bounds: mmorph
+        # - streaming-binary # bounds: mmorph
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":
@@ -2295,8 +2295,9 @@ packages:
         # - engine-io-yesod # bounds: ghc, base
 
     "Tim McGilchrist <timmcgil@gmail.com> @tmcgilchrist":
+        []
         # - riak # bounds: aeson
-        - airship
+        # - airship # bounds: mmorph
 
     "Yuras Shumovich <shumovichy@gmail.com> @Yuras":
         - pdf-toolbox-core
@@ -3218,9 +3219,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/2528
         - concurrent-output < 1.10.0
-
-        # https://github.com/fpco/stackage/issues/2529
-        - mmorph < 1.1.0
 
         # https://github.com/fpco/stackage/issues/2604
         - criterion < 1.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -288,7 +288,6 @@ packages:
         - async
         - base16-bytestring
         - c2hs
-        - cassava
         - csv-conduit
         - executable-hash
         - executable-path
@@ -3188,6 +3187,7 @@ packages:
         - type-list
         - vinyl-utils
         - language-lua2 # https://github.com/mitchellwrosen/language-lua2/issues/4
+        - cassava
 
      # If you want to make sure a package is removed from stackage,
      # place it here with a `< 0` constraint and send a pull
@@ -3213,10 +3213,6 @@ packages:
 
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
-
-        # https://github.com/fpco/stackage/issues/2595
-        - cassava < 0.5.0.0
-        - cassava-conduit < 0.4.0.0 # because of above and #2586
 
         # https://github.com/fpco/stackage/issues/2607
         - http-media < 0.7.0
@@ -3349,6 +3345,9 @@ package-flags:
 
     mintty:
         win32-2-5: false
+
+    cassava:
+        pre-bytestring-0-10-4: false
 
 # end of package-flags
 
@@ -3580,6 +3579,7 @@ skipped-tests:
     - tar
     - vector-builder
     - zlib
+    - text-short
 
 # end of skipped-tests
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3207,11 +3207,8 @@ packages:
         - concurrent-output < 1.10.0 # Wait for GHC 8.2.1
 
         # https://github.com/fpco/stackage/issues/2557
-        - singletons < 2.3
+        - singletons < 2.3 # Wait for GHC 8.2.1
         - th-desugar < 1.7
-
-        # https://github.com/fpco/stackage/issues/2562
-        - trifecta < 1.7
 
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
@@ -3427,6 +3424,7 @@ skipped-tests:
     - distributive
     - email-validate
     - flow
+    - trifecta
     # - genvalidity-property # bounds: QuickCheck
     - hasmin
     - http-api-data

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -183,8 +183,8 @@ packages:
         - binary-parsers
         - binary-ieee754
         - word24
-        - mysql-haskell
-        - mysql-haskell-openssl
+        # - mysql-haskell # bounds: memory
+        # - mysql-haskell-openssl # bounds: tcp-streams
         - data-has
 
     "Harendra Kumar <harendra.kumar@gmail.com> @harendra-kumar":
@@ -3118,7 +3118,8 @@ packages:
         - mnist-idx
 
     "Naushadh <naushadh@protonmail.com> @naushadh":
-        - persistent-mysql-haskell
+        []
+        # - persistent-mysql-haskell # bounds: tcp-streams
 
     "Moritz Schulte <mtesseract@silverratio.net> @mtesseract":
         - async-refresh
@@ -3198,11 +3199,6 @@ packages:
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
-
-        # https://github.com/fpco/stackage/issues/2334
-        - tcp-streams < 1.0.0.0
-        - tcp-streams-openssl < 1.0.0.0
-        - mysql-haskell < 0.8.1.0
 
         # https://github.com/fpco/stackage/issues/2393
         - HUnit < 1.6.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3203,9 +3203,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2393
         - HUnit < 1.6.0.0
 
-        # https://github.com/fpco/stackage/issues/2400
-        - hslua < 0.5
-
         # https://github.com/fpco/stackage/issues/2449
         - aeson < 1.2.0.0
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3241,7 +3241,10 @@ packages:
         - doctest < 0.12
 
         # https://github.com/fpco/stackage/issues/2666
-        - megaparsec < 6.0
+        - megaparsec < 6
+        - hspec-megaparsec < 1
+        - versions < 3.2
+
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2268,9 +2268,9 @@ packages:
         # - distributed-process-simplelocalnet # via: distributed-process
         - distributed-static
         - network-transport
-        - network-transport-tcp
-        - network-transport-inmemory
-        - network-transport-composed
+        # - network-transport-tcp # bounds: network-transport
+        # - network-transport-inmemory # bounds: network-transport
+        # - network-transport-composed # bounds: network-transport
         - rank1dynamic
 
     # "Alexander Vershilov <alexander.vershilov@tweag.io> @qnikst":
@@ -3198,9 +3198,6 @@ packages:
     "Stackage upper bounds":
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
-
-        # https://github.com/fpco/stackage/issues/2329
-        - network-transport < 0.5
 
         # https://github.com/fpco/stackage/issues/2334
         - tcp-streams < 1.0.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3228,9 +3228,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2550
         - foldl < 1.3.0
 
-        # https://github.com/fpco/stackage/issues/2555
-        - streaming-commons < 0.1.18
-
         # https://github.com/fpco/stackage/issues/2557
         - singletons < 2.3
         - th-desugar < 1.7

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3214,9 +3214,6 @@ packages:
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
 
-        # https://github.com/fpco/stackage/issues/2607
-        - http-media < 0.7.0
-
         # https://github.com/fpco/stackage/issues/2617
         - brick < 0.19
         - hledger-iadd < 1.2.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2146,7 +2146,7 @@ packages:
 
     "Ivan Miljenovic <Ivan.Miljenovic@gmail.com> @ivan-m":
         - fgl
-        - fgl-arbitrary
+        # - fgl-arbitrary # bouns: QuickCheck
         - graphviz
         - wl-pprint-text
 
@@ -3240,18 +3240,6 @@ packages:
         - tasty-quickcheck < 0.9
         - arithmoi < 0.5.0.1
 
-        # https://github.com/fpco/stackage/issues/2586
-        - QuickCheck < 2.10
-        - aeson-compat < 0.3.7
-        - arithmoi < 0.5.0.1
-        - binary-orphans < 0.1.7.0
-        - lattices < 1.6.0
-        - quickcheck-instances < 0.3.13
-        - text-show < 3.6.2
-        - text-show-instances < 3.6.1
-        - these < 0.7.4
-        - aeson-extra < 0.4.1.0
-
         # https://github.com/fpco/stackage/issues/2587
         - extra < 1.6
 
@@ -3456,7 +3444,7 @@ skipped-tests:
     - distributive
     - email-validate
     - flow
-    - genvalidity-property
+    # - genvalidity-property # bounds: QuickCheck
     - hasmin
     - http-api-data
     - intervals
@@ -3590,8 +3578,22 @@ skipped-tests:
     # wrong package.yaml file
     - teardown # https://github.com/roman/Haskell-teardown/issues/1
 
-    # waiting for QuickCheck == 2.10.*
-    - integer-logarithms
+    # QuickCheck 2.10
+    - arithmoi
+    - blaze-html
+    - blaze-markup
+    - cassava-conduit
+    - edit-distance
+    - http-media
+    - morte
+    - printcess
+    - retry
+    - superbuffer
+    - unbound
+    - vector
+    - wai-middleware-rollbar
+    - websockets
+    - path
 
 # end of skipped-tests
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3444,6 +3444,36 @@ skipped-tests:
     # Outdated dependencies
     # These can periodically be checked for updates;
     # just remove these lines and run `stackage-curator check' to verify.
+    # doctest 0.12
+    - ad
+    - attoparsec-time
+    - bits
+    - bound
+    - bytes
+    - cgi
+    - clash-prelude
+    - comonad
+    - distributive
+    - email-validate
+    - flow
+    - genvalidity-property
+    - hasmin
+    - http-api-data
+    - intervals
+    - lens
+    - lens-aeson
+    - linear
+    - linear-accelerate
+    - log-domain
+    - makefile
+    - pipes-group
+    - prettyprinter
+    - semigroupoids
+    - servant-ruby
+    - servant-swagger
+    - tdigest
+    - turtle
+    - zippers
     # # HUnit 1.5
     - GLFW-b
     - Glob

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3232,6 +3232,7 @@ packages:
         - inline-c < 0.6.0.0
         - inline-c-cpp < 0.2.0.0
         - packdeps < 0.4.4
+        - cabal2nix < 2.4
 
         # https://github.com/fpco/stackage/issues/2661
         - servant-docs < 0.11

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -901,7 +901,7 @@ packages:
         # - darcs # bounds: graphviz < 2999.19
         - hledger
         - hledger-lib
-        - hledger-ui
+        # - hledger-ui # bounds: brick
         - hledger-web
         - hledger-api
         # - shelltestrunner # bounds: Diff, HUnit
@@ -3220,9 +3220,6 @@ packages:
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
 
-        # https://github.com/fpco/stackage/issues/2617
-        - brick < 0.19
-        - hledger-iadd < 1.2.2
 
         # https://github.com/fpco/stackage/issues/2628
         - hledger-lib < 1.3

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -155,8 +155,8 @@ packages:
 
     "Luke Murphy <lukewm@riseup.net> @lwm":
         - tasty-discover
-        - lentil
-        - packunused
+        # - lentil # bounds: optparse-applicative
+        # - packunused # bounds: optparse-applicative
 
     "Marco Zocca @ocramz":
         - sparse-linear-algebra
@@ -579,17 +579,17 @@ packages:
         - active
         # - BlogLiterately # bounds: skylighting
         # - BlogLiterately-diagrams # bounds: skylighting
-        - diagrams
+        # - diagrams # bounds: optparse-applicative
         - diagrams-builder
         # - diagrams-haddock # BLOCKED directory 1.3 via cautious-file
-        - diagrams-cairo # bounds: vector
+        # - diagrams-cairo # bounds: optparse-applicative
         - diagrams-contrib
         - diagrams-core
-        - diagrams-gtk
+        # - diagrams-gtk # bounds: optparse-applicative
         - diagrams-lib
         - diagrams-postscript
-        - diagrams-rasterific
-        - diagrams-svg
+        # - diagrams-rasterific # bounds: optparse-applicative
+        # - diagrams-svg # bounds: optparse-applicative
         - dual-tree
         - force-layout
         - haxr
@@ -1191,10 +1191,10 @@ packages:
 
     "Jeffrey Rosenbluth <jeffrey.rosenbluth@gmail.com> @jeffreyrosenbluth":
         - palette
-        - diagrams-canvas
-        - diagrams-rasterific
+        # - diagrams-canvas # bounds: optparse-applicative
+        # - diagrams-rasterific # bounds: optparse-applicative
         - lucid-svg
-        - diagrams-html5
+        # - diagrams-html5 # bounds: optparse-applicative
         - static-canvas
         - svg-builder
 
@@ -1267,7 +1267,7 @@ packages:
         - spdx
         - splitmix
         - tdigest
-        - tdigest-Chart
+        # - tdigest-Chart # bounds: optparse-applicative
         - these
         - time-parsers
         - waitra
@@ -1549,7 +1549,7 @@ packages:
     "Noam Lewis <jones.noamle@gmail.com> @sinelaw":
         - xml-to-json
         - xml-to-json-fast
-        - resolve-trivial-conflicts
+        # - resolve-trivial-conflicts # bounds: optparse-applicative
         - wl-pprint
         # not a maintainer
         - hxt-curl
@@ -2562,7 +2562,7 @@ packages:
         - tuple
         - OneTuple
         - SVGFonts
-        - Chart-diagrams
+        # - Chart-diagrams # bounds optparse-applicative
 
     # "Aaron Levin <aaron.levin@soundcloud.com> @aaronmblevin":
         # - haskell-kubernetes # bounds: QuickCheck, aeson, http-api-data, lens, servant, servant-client
@@ -2899,8 +2899,8 @@ packages:
     "Tony Day <tonyday567@gmail.com> @tonyday567":
         - numhask
         - numhask-range
-        - chart-unit
-        - perf
+        # - chart-unit # bounds optparse-applicative
+        # - perf # bounds optparse-applicative
         - online
 
     "Iphigenia Df <iphydf@gmail.com> @iphydf":
@@ -2917,7 +2917,7 @@ packages:
         - clock-extras
         - next-ref
         - tmp-postgres
-        - postgresql-simple-opts
+        # - postgresql-simple-opts # bounds: optparse-applicative
         - pg-transact
         - hspec-pg-transact
         - postgresql-simple-queue
@@ -3212,9 +3212,6 @@ packages:
 
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
-
-        # https://github.com/fpco/stackage/issues/2569
-        - optparse-applicative < 0.14
 
         # https://github.com/fpco/stackage/issues/2587
         - extra < 1.6

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1892,7 +1892,7 @@ packages:
 
     "Stack Builders stackage@stackbuilders.com @stackbuilders":
         - atomic-write
-        - hapistrano
+        # - hapistrano # bounds: path-io
         - inflections
         - twitter-feed
         # - cassava-megaparsec # via cassava: bounds: vector
@@ -3228,9 +3228,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2557
         - singletons < 2.3
         - th-desugar < 1.7
-
-        # https://github.com/fpco/stackage/issues/2559
-        - path-io < 1.3
 
         # https://github.com/fpco/stackage/issues/2562
         - trifecta < 1.7

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3204,12 +3204,7 @@ packages:
         - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
 
         # https://github.com/fpco/stackage/issues/2528
-        - concurrent-output < 1.10.0
-
-        # https://github.com/fpco/stackage/issues/2604
-        - criterion < 1.2
-        - statistics < 0.14
-        - thread-local-storage < 0.1.2
+        - concurrent-output < 1.10.0 # Wait for GHC 8.2.1
 
         # https://github.com/fpco/stackage/issues/2557
         - singletons < 2.3
@@ -3923,6 +3918,12 @@ skipped-benchmarks:
     - graphviz
     - graphviz
     - wl-pprint-text
+
+    # criterion 1.2
+    - binary-parsers
+    - cryptohash-sha512
+    - ed25519
+    - unordered-containers
 
 # end of skipped-benchmarks
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -889,7 +889,7 @@ packages:
         - rest-client
         - rest-core
         - rest-gen
-        - rest-happstack
+        # - rest-happstack # bounds happstack-server
         - rest-snap
         - rest-stringmap
         - rest-types
@@ -3230,9 +3230,6 @@ packages:
         - hledger-api < 1.3
         - hledger-ui < 1.3
         - hledger-web < 1.3
-
-        # https://github.com/fpco/stackage/issues/2656
-        - happstack-server < 7.5.0
 
         # ghc-8.2.1
         # https://github.com/fpco/stackage/issues/2659

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1,4 +1,10 @@
 ghc-major-version: "8.0"
+
+# This affects which version of the Cabal file format we allow. We
+# should ensure that this is always no greater than the version
+# supported by the most recent cabal-install and Stack releases.
+cabal-format-version: "1.24"
+
 # Constraints for brand new builds
 packages:
     "Jacob Stanley <jacob@stanley.io> @jystic":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3228,9 +3228,6 @@ packages:
         - hledger-ui < 1.3
         - hledger-web < 1.3
 
-        # https://github.com/fpco/stackage/issues/2635
-        - cryptonite < 0.24
-
         # https://github.com/fpco/stackage/issues/2646
         - cron < 0.6
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2879,7 +2879,7 @@ packages:
         - vector-mmap
 
     "Alex Mason <alex.mason@data61.csiro.au> @Axman6":
-      - foldl-statistics
+      # - foldl-statistics # bounds: foldl
       - amazonka-s3-streaming
 
     "Ondrej Palkovsky <palkovsky.ondrej@gmail.com> @ondrap":
@@ -3224,9 +3224,6 @@ packages:
         - criterion < 1.2
         - statistics < 0.14
         - thread-local-storage < 0.1.2
-
-        # https://github.com/fpco/stackage/issues/2550
-        - foldl < 1.3.0
 
         # https://github.com/fpco/stackage/issues/2557
         - singletons < 2.3

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2442,7 +2442,7 @@ packages:
         - file-modules
         - frontmatter
         - read-editor
-        - hspec-setup
+        # - hspec-setup # bounds: haskell-src-exts
         # - hzulip # bounds: aeson, stm-conduit
         - list-prompt
         # - memoization-utils # bounds: time
@@ -3102,17 +3102,17 @@ packages:
         - lens-labels
         - proto-lens
         - proto-lens-descriptors
-        - proto-lens-protoc
-        - proto-lens-combinators
+        # - proto-lens-protoc # bounds: haskell-src-exts
+        # - proto-lens-combinators # bounds: proto-lens-protoc
         - proto-lens-arbitrary
         - proto-lens-optparse
-        - proto-lens-protobuf-types
-        - tensorflow
-        - tensorflow-core-ops
-        - tensorflow-opgen
-        - tensorflow-ops
-        - tensorflow-proto
-        - tensorflow-test
+        # - proto-lens-protobuf-types # bounds: proto-lens-protoc
+        # - tensorflow # bounds: proto-lens-protoc
+        # - tensorflow-core-ops # bounds: tensorflow
+        # - tensorflow-opgen # bounds: tensorflow
+        # - tensorflow-ops # bounds: tensorflow
+        # - tensorflow-proto # bounds: proto-lens-protoc
+        # - tensorflow-test # bounds: tensorflow
 
     "Christof Schramm <christof.schramm@campus.lmu.de>":
         - mnist-idx
@@ -3196,9 +3196,6 @@ packages:
         - Win32 == 2.3.1.1
 
     "Stackage upper bounds":
-        # https://github.com/fpco/stackage/issues/2037
-        - haskell-src-exts < 1.19
-
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3203,9 +3203,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2127
         - leapseconds-announced < 2017.0.0.1 # Wait for GHC 8.2.1
 
-        # https://github.com/fpco/stackage/issues/2393
-        - HUnit < 1.6.0.0
-
         # https://github.com/fpco/stackage/issues/2451
         - websockets < 0.11.0.0
         - servant-subscriber < 0.6.0.1
@@ -3592,6 +3589,9 @@ skipped-tests:
     - websockets
     - path
     - aeson
+
+    # HUnit 1.6
+    - terminal-progress-bar
 
 # end of skipped-tests
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -927,8 +927,9 @@ packages:
         # - system-canonicalpath # bounds: ghc, base # https://github.com/d12frosted/CanonicalPath/issues/5
 
     "Daniel Gröber <dxld@darkboxed.org> @DanielG":
+        []
         # - ghc-mod # bounds: syb
-        - cabal-helper
+        # - cabal-helper # bounds: extra
 
     "Yann Esposito <yann.esposito@gmail.com> yogsototh @yogsototh":
         - human-readable-duration
@@ -3212,9 +3213,6 @@ packages:
 
         # https://github.com/haskell/haddock/issues/634 - causes other docs to fail to build
         - haddock < 2.17.5
-
-        # https://github.com/fpco/stackage/issues/2587
-        - extra < 1.6
 
         # https://github.com/fpco/stackage/issues/2595
         - cassava < 0.5.0.0


### PR DESCRIPTION
This retains upper bounds directly related to GHC 8.2.1, and some recently released packages.