### PR TITLE
Unblock hledger-iadd

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3032,8 +3032,7 @@ packages:
         # - hip # via repa: bounds: vector
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
-        []
-        # - hledger-iadd # bounds: hledger-lib
+        - hledger-iadd
 
     "Roy Levien <royl@aldaron.com> @orome":
         []


### PR DESCRIPTION
Was blocked in 1842f09361 but release 1.2.4 works again with the
latest hledger-lib.