### PR TITLE
Add selda + associated packages back in

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3214,9 +3214,9 @@ packages:
 
     "Anton Ekblad <anton@ekblad.cc> @valderman":
         []
-        # - selda # https://github.com/valderman/selda/issues/41
-        # - selda-sqlite # via selda
-        # - selda-postgresql # via selda
+        - selda
+        - selda-sqlite
+        - selda-postgresql
 
     "Luis Pedro Coelho <luis@luispedro.org> @luispedro":
         - safeio

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3213,7 +3213,6 @@ packages:
         - composable-associations-aeson
 
     "Anton Ekblad <anton@ekblad.cc> @valderman":
-        []
         - selda
         - selda-sqlite
         - selda-postgresql


### PR DESCRIPTION
GHC 8.2 build failure is fixed as of 0.1.10.0.