### PR TITLE
hquantlib on GHC 8.2.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2797,8 +2797,7 @@ packages:
         - leapseconds-announced
 
     "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
-        []
-        # - hquantlib # GHC 8.2.1
+        - hquantlib
         # - persistent-redis # GHC 8.2.1
 
     "Henri Verroken <henriverroken@gmail.com> @hverr":


### PR DESCRIPTION
The package constraints was relaxed and the build has been tested locally against nightly-2017-07-31.

Related to #2678.