### PR TITLE
Uncomment sensu-run and viewprof

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3064,9 +3064,8 @@ packages:
         - snowtify
 
     "Mitsutoshi Aoe <maoe@foldr.in> @maoe":
-        []
-        # - sensu-run # GHC 8.2.1 via wreq
-        # - viewprof # GHC 8.2.1
+        - sensu-run
+        - viewprof
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         # - postgresql-typed # GHC 8.2.1


### PR DESCRIPTION
Both packages build fine with GHC 8.2.1 using cabal-install. Currently sensu-run doesn't build with Stackage nightly due to wreq and viewprof doesn't either due to brick and its dependencies though.