### PR TITLE
Enable `extensible` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1720,7 +1720,7 @@ packages:
     "Fumiaki Kinoshita <fumiexcel@gmail.com> @fumieval":
         - boundingboxes
         - control-bool
-        # - extensible # GHC 8.2.1 via effin
+        - extensible
         - monad-skeleton
         - objective
         - witherable


### PR DESCRIPTION
Updated the package bound for `effin` and uploaded a new version to Hackage.
see: https://github.com/YellPika/effin/commit/de6cbe5ecf0876f788365e3e435cb9732fa6b79d
hackage: https://hackage.haskell.org/package/effin-0.3.0.3
