### PR TITLE
Enable `http-media` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1237,8 +1237,7 @@ packages:
         - network-anonymous-tor
 
     "Timothy Jones <tim@zmthy.net> @zmthy":
-        []
-        # - http-media # GHC 8.2.1
+        - http-media
 
     "Greg V <greg@unrelenting.technology> @myfreeweb":
         # - gitson # GHC 8.2.1 via flock


### PR DESCRIPTION
Updated the package bound for `http-media` and uploaded a new version to Hackage.
see: https://github.com/zmthy/http-media/commit/26b813693817f1b8d479316cf3798118004ac2d1
Hackage: https://hackage.haskell.org/package/http-media-0.7.1.1