### PR TITLE
Enable `chatwork` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -15,10 +15,8 @@ packages:
         - hedgehog
         - hedgehog-quickcheck
 
-    "Nobutada Matsubara <t12307043@gunma-u.ac.jp> @matsubara0507": []
-        # package temprarily removed as added while blocked on req-0.3.0;
-        # see https://github.com/fpco/stackage/issues/2641
-        # - chatwork
+    "Nobutada Matsubara <t12307043@gunma-u.ac.jp> @matsubara0507":
+        - chatwork
 
     "Pavol Klacansky <pavol@klacansky.com> @pavolzetor":
         - openexr-write


### PR DESCRIPTION
Enabled `req-0.3.1` in nightly-2017-07-31. 
see: https://github.com/fpco/stackage/issues/2641