### PR TITLE
Attempt to reenable clr-inline

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -42,7 +42,7 @@ packages:
         - hp2pretty # With permission of Claude Heiland-Allend
         - floatshow # https://bitbucket.org/dafis/floatshow/issues/1/add-to-stackage
         # - threepenny-editors # GHC 8.2.1 via threepenny-gui
-        # - clr-inline  # possibly nondeterministic failures, see https://github.com/fpco/stackage/issues/2510, and https://gitlab.com/tim-m89/clr-haskell/issues/28
+        - clr-inline  # possibly nondeterministic failures, see https://github.com/fpco/stackage/issues/2510
 
 
     "Joshua Koike <jkoike2013@gmail.com> @jano017":


### PR DESCRIPTION
clr-inline 0.2.0 has been released including ghc 8.2.1 fixes