### PR TITLE
New version of libmpd is released in Hackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -409,7 +409,7 @@ packages:
         - hourglass-orphans
         - wai-slack-middleware
         - sysinfo
-        # - xmonad-extras # GHC 8.2.1 via libmpd
+        - xmonad-extras
 
     "haskell-openal":
         - OpenAL
@@ -2883,8 +2883,7 @@ packages:
         # - dictionaries # GHC 8.2.1
 
     "Joachim Fasting <joachifm@fastmail.fm> @joachifm":
-        []
-        # - libmpd # GHC 8.2.1
+        - libmpd
 
     "Moritz Kiefer <moritz.kiefer@purelyfunctional.org> @cocreature":
         - lrucaching


### PR DESCRIPTION
xmonad-extras should build for ghc-8.2 now.

Related fix: https://github.com/vimus/libmpd-haskell/pull/95