### PR TITLE
Try enabling all packages related to email-validate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -277,7 +277,7 @@ packages:
         - warp-tls
         # - yackage # GHC 8.2.1 via yesod-form
         - yesod
-        # - yesod-auth # GHC 8.2.1 via email-validate
+        - yesod-auth
         - authenticate-oauth
         - yesod-bin
         - yesod-eventsource
@@ -380,8 +380,7 @@ packages:
         # - HaRe # via: ghc-mod
 
     "Alfredo Di Napoli <alfredo.dinapoli@gmail.com> @adinapoli":
-        []
-        # - mandrill # GHC 8.2.1 via email-validate
+        - mandrill
 
     "Jon Schoning <jonschoning@gmail.com> @jonschoning":
         - pinboard
@@ -405,7 +404,7 @@ packages:
         - tldr
         - fb
         - yesod-fb
-        # - yesod-auth-fb # GHC 8.2.1 via yesod-auth
+        - yesod-auth-fb
         - hourglass-orphans
         - wai-slack-middleware
         - sysinfo
@@ -469,7 +468,7 @@ packages:
         # - labels # https://github.com/chrisdone/labels/issues/8
         - ace
         - ical
-        # - check-email # GHC 8.2.1 via email-validate
+        - check-email
         - freenect
         - frisby
         - gd
@@ -2092,7 +2091,7 @@ packages:
         - irc
 
     "Dennis Gosnell <cdep.illabout@gmail.com> @cdepillabout":
-        # - emailaddress # GHC 8.2.1 via email-validate
+        - emailaddress
         - envelope
         - from-sum
         # - hailgun # GHC 8.2.1
@@ -3234,8 +3233,7 @@ packages:
         - shikensu
 
     "George Pollard <porges@porg.es> @Porges":
-        []
-        # - email-validate # GHC 8.2.1
+        - email-validate
 
     "Alexander Ignatyev <ignatyev.alexander@gmail.com> @alexander-ignatyev":
         - astro


### PR DESCRIPTION
A new version of `email-validate` has been released which builds fine
with `nightly-2017-07-31`.

I actually just care about yesod-auth-fb. But going from the comments,
I think it should enable building of other packages. Let me know if
such a patch is not intended.