### PR TITLE
Use time >= 1.8 for timezone-series

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3334,7 +3334,7 @@ package-flags:
         containers: false
 
     timezone-series:
-        time_1_6_and_1_7: true
+        time_1_6_and_1_7: false
         time_pre_1_6: false
 
     mintty:


### PR DESCRIPTION
Update flags for timezone-series to use time >= 1.8 so that it will work with GHC 8.2.