### PR TITLE
Re-enable Earley

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -352,7 +352,7 @@ packages:
         - multiarg
         # - prednote # GHC 8.2.1 via lens-simple
         - cartel
-        # - Earley # GHC 8.2.1
+        - Earley
         - ofx
         # - pinchot # GHC 8.2.1
         - accuerr


### PR DESCRIPTION
The latest version of Earley now works with GHC 8.2.1.