### PR TITLE
re-enable `extensible` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1724,7 +1724,7 @@ packages:
     "Fumiaki Kinoshita <fumiexcel@gmail.com> @fumieval":
         - boundingboxes
         - control-bool
-        # - extensible # BLOCKED freer-effects compilation failure
+        - extensible
         - monad-skeleton
         - objective
         - witherable
@@ -3919,6 +3919,9 @@ expected-benchmark-failures:
 
     # https://github.com/raaz-crypto/raaz/issues/338
     - raaz
+
+    # freer-effects compilation failure
+    - extensible 
 
 # end of expected-benchmark-failures
 


### PR DESCRIPTION
`extensible` package use freer-effect only in benchmark.
see: https://github.com/fumieval/extensible/blob/master/extensible.cabal#L103