### PR TITLE
add leancheck

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2092,6 +2092,9 @@ packages:
         # - irc-conduit # GHC 8.2.1
         # - irc-client # GHC 8.2.1
 
+    "Rudy Matela <rudy@matela.com.br> @rudymatela":
+        - leancheck
+
     "Trevor Elliott <awesomelyawesome@gmail.com> @elliottt":
         - irc
 


### PR DESCRIPTION
Add the [leancheck] property-based testing library.

LeanCheck is under [CI] and compiles against GHC 8.2.1.

[LeanCheck is already available on stackage lts-9.0] -- added there because it is a dependency of [dejafu], I think.

[leancheck]: https://github.com/rudymatela/leancheck
[CI]: https://travis-ci.org/rudymatela/leancheck
[LeanCheck is already available on stackage lts-9.0]: https://www.stackage.org/lts-9.0/package/leancheck-0.6.3
[dejafu]: https://github.com/barrucadu/dejafu