### PR TITLE
Add fitspec, speculate and extrapolate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2094,6 +2094,9 @@ packages:
 
     "Rudy Matela <rudy@matela.com.br> @rudymatela":
         - leancheck
+        - fitspec
+        - speculate
+        - extrapolate
 
     "Trevor Elliott <awesomelyawesome@gmail.com> @elliottt":
         - irc


### PR DESCRIPTION
Add the [fitspec], [speculate] and [extrapolate] property-based testing libraries.

All three tools are under CI and compile against GHC 8.2.1, see:
* [FitSpec on Travis];
* [Speculate on Travis];
* [Extrapolate on Travis].

[fitspec]: https://github.com/rudymatela/fitspec
[speculate]: https://github.com/rudymatela/speculate
[extrapolate]: https://github.com/rudymatela/extrapolate
[FitSpec on Travis]: https://travis-ci.org/rudymatela/fitspec
[Speculate on Travis]: https://travis-ci.org/rudymatela/speculate
[Extrapolate on Travis]: https://travis-ci.org/rudymatela/extrapolate