### PR TITLE
Re-enable avers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1194,10 +1194,10 @@ packages:
         # - pipes-network # bounds: pipes 4.3
 
     "Tomas Carnecky @wereHamster":
-        # - avers # GHC 8.2.1
-        # - avers-api # GHC 8.2.1
+        - avers
+        - avers-api
         # - avers-api-docs # GHC 8.2.1
-        # - avers-server # GHC 8.2.1
+        - avers-server
         - css-syntax
         - etcd
         - github-types


### PR DESCRIPTION
avers-api-docs remains disabled because it depends on swagger2.