### PR TITLE
restore hsexif, it works OK now

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2286,7 +2286,7 @@ packages:
 
     "Emmanuel Touzery <etouzery@gmail.com> @emmanueltouzery":
         - app-settings
-        # - hsexif # GHC 8.2.1
+        - hsexif
 
     "Nickolay Kudasov <nickolay.kudasov@gmail.com> @fizruk":
         []


### PR DESCRIPTION
hsexif was removed from stackage supposedly due to incompatibility with ghc-8.2.1, but it works OK for me. there was an issue with the `time` dependency which i fixed recently, and I think that due to that it came to some confusion and hsexif was mistakenly thought to be incompatible with 8.2. This patch re-enables it.