### PR TITLE
Reenable hexml-lens tests and haddocks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3645,9 +3645,6 @@ skipped-tests:
     # https://github.com/brunjlar/pell/issues/1
     - pell
 
-    # https://github.com/pepeiborra/hexml-lens/issues/2
-    - hexml-lens
-
     # https://github.com/bos/wreq/issues/107
     - wreq
 
@@ -3970,9 +3967,6 @@ expected-haddock-failures:
 
     # https://github.com/kuribas/cubicbezier/issues/4
     - cubicbezier
-
-    # https://github.com/pepeiborra/hexml-lens/issues/1
-    - hexml-lens
 
 # end of expected-haddock-failures
 


### PR DESCRIPTION
Fixed now in Hackage.