### PR TITLE
HaTeX tests no longer expected to fail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3879,9 +3879,6 @@ expected-test-failures:
     # https://github.com/winterland1989/binary-parsers/issues/3
     - binary-parsers
 
-    # https://github.com/Daniel-Diaz/HaTeX/issues/100
-    - HaTeX
-
     # https://github.com/raaz-crypto/raaz/issues/337
     - raaz
 


### PR DESCRIPTION
Issue https://github.com/Daniel-Diaz/HaTeX/issues/100 was fixed and HaTeX-3.17.3.1 released.