### PR TITLE
Remove myself from haskell-packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2855,7 +2855,6 @@ packages:
         # - mixed-types-num # GHC 8.2.1
 
     "Bartosz Nitka <niteria@gmail.com> @niteria":
-        # - haskell-packages # Cabal 2.0.0.2
         - oeis
 
     "Gergely Patai <patai.gergely@gmail.com> @cobbpg":


### PR DESCRIPTION
I'm no longer interested in keeping this package in stackage. It used to be a dependency of `haskell-names`, but now it isn't, so I have no use for this package.

Cc other `haskell-packages` maintainers: @Lemmih