### PR TITLE
Re-enable christiaanb's ghc-typelits-* packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1681,11 +1681,10 @@ packages:
         - tasty-hspec
 
     "Christiaan Baaij <christiaan.baaij@gmail.com> @christiaanb":
-        []
-        # - ghc-tcplugins-extra # GHC 8.2.1
-        # - ghc-typelits-extra # GHC 8.2.1
-        # - ghc-typelits-knownnat # GHC 8.2.1
-        # - ghc-typelits-natnormalise # GHC 8.2.1
+        - ghc-tcplugins-extra
+        - ghc-typelits-extra
+        - ghc-typelits-knownnat
+        - ghc-typelits-natnormalise
         # - clash-prelude # GHC 8.2.1
         # - clash-lib # GHC 8.2.1
         # - clash-vhdl # GHC 8.2.1


### PR DESCRIPTION
They all successfully build on GHC 8.2.1