### PR TITLE
Re-enable hmatrix dependants

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -162,7 +162,7 @@ packages:
         # - text-generic-pretty # GHC 8.2.1 via ixset-typed
 
     "Li-yao Xia <lysxia@gmail.com> @Lysxia":
-        # - boltzmann-samplers # https://github.com/albertoruiz/hmatrix/issues/232
+        - boltzmann-samplers
         - generic-random
 
     "Tobias Dammers <tdammers@gmail.com> @tdammers":
@@ -1550,7 +1550,7 @@ packages:
         # - mbox # GHC 8.2.1
         - kmeans
         - boolsimplifier
-        # - cubicspline # https://github.com/albertoruiz/hmatrix/issues/232
+        - cubicspline
         - maximal-cliques
 
     "Alexander Bondarenko <aenor.realm@gmail.com> @wiz":
@@ -1562,9 +1562,9 @@ packages:
         - generics-sop
 
     "Vivian McPhail <haskell.vivian.mcphail@gmail.com> @amcphail":
-        # - hmatrix-gsl-stats # https://github.com/albertoruiz/hmatrix/issues/232
-        # - hsignal # https://github.com/albertoruiz/hmatrix/issues/232
-        # - hstatistics # https://github.com/albertoruiz/hmatrix/issues/232
+        - hmatrix-gsl-stats
+        - hsignal
+        - hstatistics
         # - plot # Cabal 2.0.0.2
         # - plot-gtk # Cabal 2.0.0.2
         # - plot-gtk3 # Cabal 2.0.0.2
@@ -2807,8 +2807,7 @@ packages:
         - leapseconds-announced
 
     "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
-        []
-        # - hquantlib # https://github.com/albertoruiz/hmatrix/issues/232
+        - hquantlib
         # - persistent-redis # GHC 8.2.1
 
     "Henri Verroken <henriverroken@gmail.com> @hverr":
@@ -2995,7 +2994,7 @@ packages:
         # - language-python # https://github.com/bjpop/language-python/issues/35
 
     "Mahdi Dibaiee <mdibaiee@aol.com>":
-        # - picedit # https://github.com/albertoruiz/hmatrix/issues/232
+        - picedit
         - mathexpr
         # - sibe # GHC 8.2.1 via stemmer
         - termcolor
@@ -3247,7 +3246,7 @@ packages:
 
     "Alexander Ignatyev <ignatyev.alexander@gmail.com> @alexander-ignatyev":
         - astro
-        # - mltool # https://github.com/albertoruiz/hmatrix/issues/232
+        - mltool
 
     "Edward Amsden <edwardamsden@gmail.com> @eamsden":
         - h2c


### PR DESCRIPTION
hmatrix compiles with GHC 8.2.1 now

https://github.com/fpco/stackage/pull/2756