### PR TITLE
Add HSvm to LTS-9

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2747,6 +2747,7 @@ packages:
     "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
         - hquantlib
         - persistent-redis
+        - HSvm
 
     "Henri Verroken <henriverroken@gmail.com> @hverr":
         - cache


### PR DESCRIPTION
HSvm package has been refreshed to be buildable with GHC 8.0.2 and 8.2.1. Put to github for better collaboration and fixed few bugs in marshalling.