### PR TITLE
Add HSvm to master

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2810,6 +2810,7 @@ packages:
 
     "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
         - hquantlib
+        - HSvm
         # - persistent-redis # GHC 8.2.1
 
     "Henri Verroken <henriverroken@gmail.com> @hverr":


### PR DESCRIPTION
HSvm package has been refreshed to be buildable with GHC 8.0.2 and 8.2.1. Put to github for better collaboration and fixed few bugs in marshalling.