### PR TITLE
Re-enable ghc-typelits-knownnat

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1682,8 +1682,8 @@ packages:
 
     "Christiaan Baaij <christiaan.baaij@gmail.com> @christiaanb":
         - ghc-tcplugins-extra
-        # - ghc-typelits-extra # Compilation failure https://github.com/fpco/stackage/pull/2766
-        # - ghc-typelits-knownnat # Compilation failure https://github.com/fpco/stackage/pull/2766
+        - ghc-typelits-extra
+        - ghc-typelits-knownnat
         - ghc-typelits-natnormalise
         # - clash-prelude # GHC 8.2.1
         # - clash-lib # GHC 8.2.1


### PR DESCRIPTION
Version 0.3.1 has a testsuite that passes on ghc-8.2.1