### PR TITLE
Return yesod-form-richtext to LTS

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1094,7 +1094,7 @@ packages:
         - zip-archive
 
     "Arthur Fayzrakhmanov <heraldhoi@gmail.com> @geraldus":
-        # - yesod-form-richtext # GHC 8.2.1 via yesod-form
+        - yesod-form-richtext
         - ghcjs-perch
 
     "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":


### PR DESCRIPTION
`yesod-form-richtext` was blocked by `yesod-form`.  The latter is in LTS 9 now, so I believe the former should be included again.