### PR TITLE
Add back `morte`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -707,7 +707,7 @@ packages:
         - pipes-safe
         - turtle
         - foldl
-        # - morte # GHC 8.2.1
+        - morte
         - bench
         - dhall
 


### PR DESCRIPTION
`stack {build,test,bench}` now work with `morte-1.6.10` against the latest nightly resolver