### PR TITLE
Add cuda

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -664,6 +664,11 @@ packages:
         - gloss-algorithms
         - gloss-raster
         - gloss-rendering
+        - cuda
+        - cublas
+        - cusparse
+        - cusolver
+        - nvvm
 
     "Liam O'Connor <liamoc@cse.unsw.edu.au> @liamoc":
         []

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -207,6 +207,24 @@ curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-l
     && rm libtensorflow.tar.gz \
     && ldconfig
 
+# Install CUDA toolkit
+# The current version can be found at: https://developer.nvidia.com/cuda-downloads
+CUDA_PKG=8.0.61-1         # update this on new version
+CUDA_VER=${CUDA_PKG:0:3}
+CUDA_APT=${CUDA_VER/./-}
+
+pushd /tmp \
+    && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_PKG}_amd64.deb \
+    && dpkg -i cuda-repo-ubuntu1604_${CUDA_PKG}_amd64.deb \
+    && apt-get update -qq \
+    && apt-get install -y cuda-drivers cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT} cuda-cublas-dev-${CUDA_APT} cuda-cusparse-dev-${CUDA_APT} cuda-cusolver-dev-${CUDA_APT} \
+    && rm cuda-repo-ubuntu1604_${CUDA_PKG}_amd64.deb \
+    && export CUDA_PATH=/usr/local/cuda-${CUDA_VER} \
+    && export LD_LIBRARY_PATH=${CUDA_PATH}/nvvm/lib64:${LD_LIBRARY_PATH} \
+    && export LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH} \
+    && export PATH=${CUDA_PATH}/bin:${PATH} \
+    && popd
+
 ## non-free repo for mediabus-fdk-aac
 #apt-add-repository multiverse \
 #    && apt-get update \


### PR DESCRIPTION
The `debian-bootstrap.sh` file should install the CUDA toolkit correctly. This is safe to do on machines without a NVIDIA GPU (I do this on travis, for example).