### PR TITLE
Add blas-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3287,6 +3287,9 @@ packages:
         - docker-build-cacher
         # - mysql-haskell-nem : blocked on mysql-haskell
 
+    "Phil Ruffwind <rf@rufflewind.com> @Rufflewind":
+        - blas-hs
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
This requires a BLAS library with the CBLAS interface.  I think it's already part of `debian-bootstrap.sh` though.