### PR TITLE
Remove dotenv-hs from expected-test-failure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3609,7 +3609,6 @@ expected-test-failures:
     - distributed-process
     - distributed-process-execution # https://github.com/haskell-distributed/distributed-process-execution/issues/2
     - distributed-process-task
-    - dotenv # https://github.com/stackbuilders/dotenv-hs/issues/58
     - foldl-statistics # https://github.com/data61/foldl-statistics/issues/2
     - fsnotify # Often runs out of inotify handles
     - hastache


### PR DESCRIPTION
@cdornan I think this time the dotenv tests won't fail. We are sure that the new package `0.5.0.1` in hackage has the expected fixtures: [dotenv source](http://hackage.haskell.org/package/dotenv-0.5.0.1/src/)