### PR TITLE
Enable language-puppet again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2251,7 +2251,7 @@ packages:
         - strict-base-types
         - withdependencies
         - hruby
-        # - language-puppet # https://github.com/bartavelle/language-puppet/issues/214
+        - language-puppet
         - tar-conduit
         # - stm-firehose # bounds: http-types, stm-conduit, transformers, wai, warp
         # - hslogstash # bounds: aeson, lens, time, transformers # via: stm-firehose


### PR DESCRIPTION
Following the fix of https://github.com/bartavelle/language-puppet/issues/214