### PR TITLE
enable hledger/-lib/-api with support for #2666

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -932,11 +932,11 @@ packages:
 
     "Simon Michael <simon@joyful.com> @simonmichael":
         # - darcs # bounds: graphviz < 2999.19
-        # - hledger     # megaparsec bounds: https://github.com/fpco/stackage/issues/2666
-        # - hledger-lib # megaparsec bounds: https://github.com/fpco/stackage/issues/2666
+        - hledger
+        - hledger-lib
         # - hledger-ui # bounds: brick
         # - hledger-web # GHC 8.2.1 via yesod-form
-        # - hledger-api # megaparsec bounds: https://github.com/fpco/stackage/issues/2666
+        - hledger-api
         # - shelltestrunner # bounds: Diff, HUnit
         - quickbench
         - regex-compat-tdfa


### PR DESCRIPTION
These packages now support megaparsec 6 and should be free of other dep issues.