### PR TITLE
drop old hledger-lib benchmarks exclusion

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3940,9 +3940,6 @@ skipped-benchmarks:
     - extensible # via freer-effects https://github.com/fumieval/extensible/issues/12
     - hw-bits # https://github.com/haskell-works/hw-bits/issues/8
 
-    # GHC Bugs
-    - hledger-lib # https://github.com/fpco/stackage/issues/1587
-
     # Cyclic dependencies
     - cassava
 


### PR DESCRIPTION
We didn't find out why these stopped working, but they run here with
GHC 8.2.1 and I think it's likely they will run again on stackage by now.
Cf https://github.com/fpco/stackage/issues/1587, 
https://github.com/simonmichael/hledger/issues/593
