### PR TITLE
Revert "re-enable hledger-lib test suite"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3794,6 +3794,7 @@ expected-test-failures:
     - haddock
     - heap # https://github.com/pruvisto/heap/issues/4
     - hledger-iadd # https://github.com/hpdeifel/hledger-iadd/issues/26
+    - hledger-lib # https://github.com/simonmichael/hledger/issues/596
     - hspec-expectations-pretty-diff # GHC 8 issue not reported upstream since issue tracker disabled
     - hweblib # https://github.com/aycanirican/hweblib/issues/3
     - language-dockerfile # https://github.com/beijaflor-io/haskell-language-dockerfile/issues/8


### PR DESCRIPTION
Reverts fpco/stackage#2835. Stil seeing a failure via https://github.com/fpco/stackage/pull/2835#issuecomment-327437992.