### PR TITLE
Switch to LLVM 5 and remove constraints on llvm-hs and llvm-hs-pure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3379,10 +3379,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2832
         - io-streams < 1.5
 
-        # https://github.com/llvm-hs/llvm-hs/issues/137
-        - llvm-hs < 5.0.0
-        - llvm-hs-pure == 4.1.0.0
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -191,9 +191,9 @@ echo "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/" > /etc/ld.so.conf
 
 # llvm-4.0 for llvm-hs (separate since it needs wget)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" \
+    && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" \
     && apt-get update \
-    && apt-get install -y llvm-4.0
+    && apt-get install -y llvm-5.0
 
 # Install version 3 of the protobuf compiler.  (The `protobuf-compiler` package only
 # supports version 2.)


### PR DESCRIPTION
I tested that the docker image still builds and that I can build `llvm-hs-5.0.0` and `llvm-hs-pure-5.0.0` in the updated image and run their tests.