### PR TITLE
Enabled Agda 2.5.3.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2033,8 +2033,7 @@ packages:
         - ipython-kernel # GHC 8
 
     "Andrés Sicard-Ramírez <asr@eafit.edu.co> @asr":
-        []
-        # - Agda # GHC 8.2.1
+        - Agda
 
     "James Cook <mokus@deepbondi.net> @mokus0":
         - dependent-sum


### PR DESCRIPTION
Agda 2.5.3 is compatible with GHC 8.2.1.