### PR TITLE
Bloodhound 0.15.0.0 for GHC 8.2.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -747,7 +747,7 @@ packages:
     "Chris Allen <cma@bitemyapp.com> @bitemyapp":
         - machines-directory
         - machines-io
-        # - bloodhound # GHC 8.2.1
+        - bloodhound
         - esqueleto
 
     "Adam Bergmark <adam@bergmark.nl> @bergmark":


### PR DESCRIPTION
I just cut bloodhound 0.15.0.0 which is now building against stackage nightlies. I'm working on katip.

If this works out, @phadej, @scrive will need to raise upper bounds and make any adjustments needed and then they can be unblocked here too.