### PR TITLE
Unblock katip and katip-elasticsearch

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2631,8 +2631,8 @@ packages:
         # - ua-parser # bounds aeson
         - hs-GeoIP
         - retry
-        # - katip # bounds aeson
-        # - katip-elasticsearch # via bloodhound: bounds: vector
+        - katip
+        - katip-elasticsearch
 
     "Sid Kapur sidharthkapur1@gmail.com @sid-kap":
         - tuple


### PR DESCRIPTION
katip-0.5.0.1 and katip-elasticsearch-0.4.0.1 now support GHC 8.2.1