### PR TITLE
Remove bound on file-embed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3389,9 +3389,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2861
         - swagger2 < 2.1.5
 
-        # https://github.com/fpco/stackage/issues/2863
-        - file-embed < 0.0.10.1
-
         # https://github.com/fpco/stackage/issues/2867
         - data-fix < 0.2
 


### PR DESCRIPTION
threepenny-gui has been updated.

Fixes #2863.