### PR TITLE
re-enable GPipe

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2170,8 +2170,7 @@ packages:
         - yi-snippet
 
     "Tobias Bexelius <tobias_bexelius@hotmail.com> @tobbebex":
-        []
-        # - GPipe # GHC 8.2.1
+        - GPipe
 
     "Patrick Redmond <plredmond@gmail.com> @plredmond":
         []


### PR DESCRIPTION
GPipe 2.2.2 now supports GHC 8.2.1 and builds using latest stackage nightly