### PR TITLE
Make mintty build with Win32-2.5.x.x

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3504,7 +3504,7 @@ package-flags:
         time_pre_1_6: false
 
     mintty:
-        win32-2-5: false
+        win32-2-5: true
 
     cassava:
         pre-bytestring-0-10-4: false


### PR DESCRIPTION
ghc-8.2.1 ships with Win32-2.5.4.1, and mintty should build with this version of Win32.