### PR TITLE
Expect linear-accelerate tests to pass

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3821,7 +3821,6 @@ expected-test-failures:
     - xmonad # 0.12 https://github.com/xmonad/xmonad/issues/36
     - yahoo-finance-api # https://github.com/fpco/stackage/issues/2821
     - bitx-bitcoin  # https://github.com/tebello-thejane/bitx.hs/issues/4
-    - linear-accelerate # https://github.com/ekmett/linear-accelerate/issues/10
 
     # Compilation failures
     - yeshql # https://bitbucket.org/tdammers/yeshql/issues/1/stackage-nightly-test-failure


### PR DESCRIPTION
ekmett/linear-accelerate#10 fixed in linear-accelerate-0.5.0.1 release