### PR TITLE
Expect accelerate-blas tests to fail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3779,6 +3779,7 @@ expected-test-failures:
     - wai-session-postgresql # PostgreSQL
     - webdriver-angular # webdriver server
     - accelerate-bignum # CUDA GPU
+    - accelerate-blas # CUDA GPU
     - gdax # Needs environment variables set
 
     # Test executable requires arguments
@@ -3852,7 +3853,6 @@ expected-test-failures:
     - wai-middleware-content-type # 0.4.1 - https://github.com/athanclark/wai-middleware-content-type/issues/2
     - xmlgen # https://github.com/skogsbaer/xmlgen/issues/6
     - yesod-auth-basic # https://github.com/creichert/yesod-auth-basic/issues/1
-    - accelerate-blas # https://github.com/fpco/stackage/pull/2880
     - servant-swagger # aeson https://github.com/fpco/stackage/issues/2879#issuecomment-331759441
 
     # Stackage upper bounds, re-enable these when their upper bound is removed


### PR DESCRIPTION
This just changes the reason the tests are expected to fail, since as of accelerate-blas-0.1.0.1 they will now at least build.