### PR TITLE
Permanently skip tests for lxd-client

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3799,6 +3799,7 @@ expected-test-failures:
     - accelerate-blas # CUDA GPU
     - gdax # Needs environment variables set
     - nakadi-client # Needs environment variable set
+    - lxd-client # https://github.com/fpco/stackage/issues/2919 # Needs LXD, not available on debian
 
     # Test executable requires arguments
     - hpqtypes
@@ -3910,7 +3911,6 @@ expected-test-failures:
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
 
     - perf # https://github.com/fpco/stackage/pull/2859
-    - lxd-client # https://github.com/fpco/stackage/issues/2919
 
 # end of expected-test-failures
 


### PR DESCRIPTION
Closes #2919 

The test suite of `lxd-client` requires LXD, which is unavailable on Debian. This PR permanently disables the `lxd-client` test suite. 