### PR TITLE
allow revised hledger* 1.4 (fixes #2917)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3416,12 +3416,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2906
         - uri-bytestring < 0.3.0
 
-        # https://github.com/fpco/stackage/issues/2917
-        - hledger < 1.4
-        - hledger-lib < 1.4
-        - hledger-ui < 1.4
-        - hledger-web < 1.4
-
         # https://github.com/sol/hpack/issues/202
         - Glob < 0.9.0
 


### PR DESCRIPTION
New revisions allow megaparsec 6.2.