### PR TITLE
Reenable aeson-injector

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2935,8 +2935,7 @@ packages:
         # - encoding-io # GHC 8.2.1
 
     "Anton Gushcha <ncrashed@gmail.com> @ncrashed":
-        []
-        # - aeson-injector # GHC 8.2.1
+        - aeson-injector
 
     "Rune K. Svendsen <runesvend@gmail.com> @runeks":
         []


### PR DESCRIPTION
> If your package ends up being temporarily removed from Stackage Nightly, please simply send a pull request to add it back once it and its dependencies are compatible with the newest GHC version.

[aeson-injector](http://hackage.haskell.org/package/aeson-injector) is now compatible with GHC 8.2.1