### PR TITLE
Updated GHC 8.2 compatibility of sparse-linear-algebra

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -190,7 +190,7 @@ packages:
         # - packunused # bounds: optparse-applicative
 
     "Marco Zocca @ocramz":
-        - sparse-linear-algebra # GHC 8.2.1 via MemoTrie
+        - sparse-linear-algebra
         - matrix-market-attoparsec
         - network-multicast
         - xeno


### PR DESCRIPTION
The latest sparse-linear-algebra (0.2.9.8) removes the transitive dependency on MemoTrie and builds on GHC 8.2