### PR TITLE
Re-add persistent-mysql-haskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3251,7 +3251,6 @@ packages:
         - mnist-idx
 
     "Naushadh <naushadh@protonmail.com> @naushadh":
-        # []
         - persistent-mysql-haskell
 
     "Moritz Schulte <mtesseract@silverratio.net> @mtesseract":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3251,8 +3251,8 @@ packages:
         - mnist-idx
 
     "Naushadh <naushadh@protonmail.com> @naushadh":
-        []
-        # - persistent-mysql-haskell # bounds: tcp-streams (see mysql-haskell)
+        # []
+        - persistent-mysql-haskell
 
     "Moritz Schulte <mtesseract@silverratio.net> @mtesseract":
         - async-refresh


### PR DESCRIPTION
mysql-haskell is back on stackage, thus making this lib stable again.