### PR TITLE
Re-enable persistent-mysql-haskell.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3253,8 +3253,7 @@ packages:
         - mnist-idx
 
     "Naushadh <naushadh@protonmail.com> @naushadh":
-        []
-        # - persistent-mysql-haskell # build failure https://github.com/fpco/stackage/pull/2956
+        - persistent-mysql-haskell
 
     "Moritz Schulte <mtesseract@silverratio.net> @mtesseract":
         - async-refresh


### PR DESCRIPTION
`persistent-mysql-haskell` was removed [41adcb7](https://github.com/fpco/stackage/commit/41adcb710a2af2ea92431ceb03b381670ed2c4d0) due to a haddock issue that wasn't caught by the Travis task. I've since patched this and verified it manually.