### PR TITLE
Removes docker from expected test failures list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3780,7 +3780,6 @@ expected-test-failures:
     - consul-haskell
     - dbcleaner # Requires running PostgreSQL server
     - dbmigrations # PostgreSQL
-    - docker # https://github.com/fpco/stackage/issues/2934
     - dns # https://github.com/kazu-yamamoto/dns/issues/29
     - drifter-postgresql # PostgreSQL
     - etcd # etcd https://github.com/fpco/stackage/issues/811


### PR DESCRIPTION
See: https://github.com/fpco/stackage/issues/2934

We should close the linked issue once this is merged. 