### PR TITLE
Add ghc-core and colorize-haskell packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3396,6 +3396,10 @@ packages:
     "Václav Haisman <vhaisman@gmail.com> @wilx":
         - hs-bibutils
 
+    "Christian Kjær Laustsen <ckl@codetalk.io> @tehnix":
+        - ghc-core
+        - colorize-haskell
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
First timer, so please let me know if anything has been done wrong. 

Also, when running `stack --resolver nightly exec stackage-curator check` I get

```
Selected resolver: nightly-2017-10-21
Loading default build constraints
Creating build plan
Determining target package versions
Parsing package descriptions
stackage-curator: CabalParseException "haddock-api/2.18.1/haddock-api.cabal" (FromString "This package requires at least Cabal version 2.0" Nothing)
```

which I'm not sure is something in the packages or something in haddock?