### PR TITLE
Remove upper bound on justified-containers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3462,9 +3462,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2967
         - swagger2 < 2.2
 
-        # https://github.com/matt-noonan/justified-containers/issues/4
-        - justified-containers < 0.2.0.0
-
         # https://github.com/fpco/stackage/issues/2971
         - either < 4.5
 


### PR DESCRIPTION
Failing test cases resolved in 0.2.0.1. See https://github.com/matt-noonan/justified-containers/issues/4