### PR TITLE
Remove upper bound constraint on hindent.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3488,9 +3488,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2971
         - either < 4.5
 
-        # https://github.com/commercialhaskell/hindent/issues/453
-        - hindent < 5.2.4
-
         # https://github.com/fpco/stackage/issues/2976
         - http-types < 0.10
         - servant-auth-cookie < 0.5.0.6


### PR DESCRIPTION
The issue commercialhaskell/hindent#453 has been fixed. Newer version of hindent (5.2.4.1) has been submitted to [hackage](http://hackage.haskell.org/package/hindent-5.2.4.1) and version 5.2.4 has been marked as deprecated.