### PR TITLE
Enable wai-middleware-throttle

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1892,7 +1892,7 @@ packages:
         - bencode
         - hsebaysdk
         - dockerfile
-        # - wai-middleware-throttle # GHC 8.2.1 via token-bucket
+        - wai-middleware-throttle
         - yesod-auth-basic
 
     "Alcides Viamontes <a.viamontes.esquivel@gmail.com> @alcidesv":


### PR DESCRIPTION
I'm still a little confused on whether the `token-bucket` dep will work, but I do want to get this package re-enabled (even if there are a few more tasks).

CC @dfithian