### PR TITLE
Expect test success on atom-conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4134,7 +4134,6 @@ expected-test-failures:
 
     # Linting failures (these may break every time HLint gets updated so keep them disabled)
     # https://www.snoyman.com/blog/2017/11/future-proofing-test-suites
-    - atom-conduit
     - conduit-parse
     - dublincore-xml-conduit
     - folds


### PR DESCRIPTION
Follow-up of https://github.com/fpco/stackage/commit/56322d1b89fa52a481444862aa32dfbe4a2cd2b8
Version 0.5.0.1 of atom-conduit has opt-in hlint test-suite. I'd like to validate on stackage that it is skipped as expected, before applying the same to other packages.