### PR TITLE
Expect test success on conduit-parse, dublincore-xml-conduit, opml-conduit, xml-conduit-parse

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4125,11 +4125,7 @@ expected-test-failures:
 
     # Linting failures (these may break every time HLint gets updated so keep them disabled)
     # https://www.snoyman.com/blog/2017/11/future-proofing-test-suites
-    - conduit-parse
-    - dublincore-xml-conduit
     - folds
-    - opml-conduit
-    - xml-conduit-parse
 
 # end of expected-test-failures
 


### PR DESCRIPTION
Follow-up of 56322d1
New versions of these packages have been released to disable hlint tests by default.