### PR TITLE
Re-enable servant-ruby and wai-middleware-rollbar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3264,9 +3264,8 @@ packages:
         - ziptastic-core
 
     "Hardy Jones <jones3.hardy@gmail.com> @joneshf":
-        []
-        # - servant-ruby # GHC 8.2.1
-        # - wai-middleware-rollbar # GHC 8.2.1
+        - servant-ruby
+        - wai-middleware-rollbar
 
     "Andrey Mokhov <andrey.mokhov@gmail.com> @snowleopard":
         - algebraic-graphs


### PR DESCRIPTION
Re #3043.

Will nudge this along through CI until it passes.