### PR TITLE
Re-add ztail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2707,6 +2707,7 @@ packages:
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed
         - invertible
+        - ztail
 
     "Louis Pan <louis@pan.me> @louispan":
         - alternators


### PR DESCRIPTION
Now updated 1.2 in-place for ghc 8.2.2 compatibility (just loosening bounds).