### PR TITLE
Re-add ttrie

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2116,6 +2116,7 @@ packages:
 
     "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":
         - ctrie
+        - ttrie
 
     "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":
         - exp-pairs


### PR DESCRIPTION
The package got disabled via atomic-primops, which is back now.