### PR TITLE
Add back 'stack'

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -957,6 +957,7 @@ packages:
         - monad-extras
         - optparse-simple
         - hpack
+        - stack
 
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
         - th-orphans
@@ -3672,7 +3673,6 @@ expected-test-failures:
 
     # Problem on the stackage build server, we need to dig deeper into
     # these if we want them fixed
-    - stack # Permissions failure when creating /home/stackage/.stack.
     - skein # openfile: does not exist https://github.com/fpco/stackage/issues/1187
     - haskell-tools-daemon # openFile: permission denied https://github.com/fpco/stackage/issues/2502
 
@@ -4039,6 +4039,7 @@ no-revisions:
 - cryptonite
 - foundation
 - gauge
+- stack
 
 # Do not build these packages in parallel with others. Useful for high memory
 # usage.


### PR DESCRIPTION
stack-1.6.1 is compatible with the latest packages on hackage, at least as of a few hours ago.  Note, however, that it needs newer versions of `unliftio` and `ansi-terminal` than are currently in nightly, so those would need to be upgraded before `stack` can be added.  Hope it was OK to open this PR anyway, but I can close it for now if that'd make things easier.

This PR also adds `stack` to the `no-revisions` list.  I initially uploaded to hackage without any dependency bounds (and then added bounds in revision 1) with the intent to use this feature.  I think that should make life easier both for myself and the stackage curators, but if that turns out to be wrong I'm happy to remove it.

I also saw that stack was disabled with this comment:

> Permissions failure when creating /home/stackage/.stack.

But that looks to be a year old, so maybe whatever that issue was is fixed?
