### PR TITLE
Add freer-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2511,6 +2511,7 @@ packages:
         - bson
 
     "Alexis King <lexi.lambda@gmail.com> @lexi-lambda":
+        - freer-simple
         - monad-mock
         - test-fixture
         - text-conversions
@@ -3850,6 +3851,8 @@ skipped-benchmarks:
     - graphviz
     - graphviz
     - wl-pprint-text
+    # @lexi-lambda https://github.com/fpco/stackage/pull/3080
+    - freer-simple
 
     - ed25519 # Criterion
 


### PR DESCRIPTION
https://hackage.haskell.org/package/freer-simple

This package includes a benchmark suite that currently intentionally benchmarks against an older version of extensible-effects, so I’ve added it to the `skipped-benchmarks` section.