### PR TITLE
Remove constraint on lspitzner/butcher

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2624,7 +2624,7 @@ packages:
     "Lennart Spitzner <hexagoxel@hexagoxel.de> @lspitzner":
         - multistate
         - pqueue
-        - butcher ==1.1.1.0
+        - butcher
         - czipwith
         - brittany
 


### PR DESCRIPTION
The newly released `brittany-0.9.0.0` works with latest released butcher.