### PR TITLE
revert bbdb expected test failure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3519,7 +3519,6 @@ expected-test-failures:
     # Missing test files in sdist
     # Hopefully gets fixed in the next release...
     - angel # https://github.com/MichaelXavier/Angel/issues/43
-    - bbdb # https://github.com/henrylaxen/bbdb/issues/1
     - camfort # 0.900 https://github.com/camfort/camfort/issues/41
     - crypto-pubkey # https://github.com/vincenthz/hs-crypto-pubkey/issues/23
     - cubicbezier # https://github.com/kuribas/cubicbezier/issues/3


### PR DESCRIPTION
You wrote:
I've marked bbdb as an expected test failure in stackage. If you're able to
correct the issue, then feel free to open a PR reverting this commit: fpco/
stackage@6b300dc.
I removed the line you added.