### PR TITLE
Re-enable GLFW

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3519,6 +3519,7 @@ expected-test-failures:
     # Missing test files in sdist
     # Hopefully gets fixed in the next release...
     - angel # https://github.com/MichaelXavier/Angel/issues/43
+    - bbdb # https://github.com/henrylaxen/bbdb/issues/1
     - camfort # 0.900 https://github.com/camfort/camfort/issues/41
     - crypto-pubkey # https://github.com/vincenthz/hs-crypto-pubkey/issues/23
     - cubicbezier # https://github.com/kuribas/cubicbezier/issues/3

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3293,7 +3293,6 @@ skipped-tests:
     - genvalidity-hspec-hashable # doctest 0.13
     - genvalidity-property # doctest 0.13
     - GLFW-b # HUnit 1.6
-    - http-api-data # doctest 0.13
     - lifted-base # HUnit 1.6
     - makefile # GHC 8.2
     - next-ref # hspec 2.3

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3296,6 +3296,7 @@ skipped-tests:
     - genvalidity-hspec-cereal # doctest 0.13
     - genvalidity-hspec-hashable # doctest 0.13
     - genvalidity-property # doctest 0.13
+    - GLFW-b # HUnit 1.6
     - http-api-data # doctest 0.13
     - lifted-base # HUnit 1.6
     - makefile # GHC 8.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -931,6 +931,7 @@ packages:
     "Pavel Krajcevski <krajcevski@gmail.com> @Mokosha":
         - netwire
         - netwire-input
+        - netwire-input-glfw
         - yoga
         - freetype2
 
@@ -1866,6 +1867,7 @@ packages:
 
     "Brian Lewis brian@lorf.org @bsl":
         - bindings-GLFW
+        - GLFW-b
 
     "Niklas Hambüchen mail@nh2.me @nh2":
         - hidapi


### PR DESCRIPTION
These packages were removed because they nominally didn't build with GHC 8.2.2, but I just checked and they seem fine. Hopefully travis will cover anything I may have missed?