### PR TITLE
Remove librato from LTS

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1641,7 +1641,6 @@ packages:
         - pipes-wai
         - serf
         - uri-templater
-        - librato
 
     "Michael Xavier <michael@michaelxavier.net> @MichaelXavier":
         - uri-bytestring


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message.
- [ ] Some time passed since Hackage upload.
- [ ] Tested with Stackage Nightly.
---

I haven't used this package in years, and to the best of my knowledge no one else has– so I intend to deprecate it. Consequently, I don't feel like it's appropriate to treat it as an LTS package at this point.
