### PR TITLE
Add sparkle and jvm-streaming.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1686,11 +1686,13 @@ packages:
         - cassette
         - choice
         - distributed-closure
-        - H
         - inline-java
         - inline-r
         - jni
         - jvm
+        - jvm-streaming
+        - H
+        - sparkle
         - th-lift
 
     "Christopher Reichert <creichert07@gmail.com> @creichert":
@@ -3277,6 +3279,13 @@ configure-args:
   - --extra-include-dirs
   - /usr/lib/jvm/java-8-openjdk-amd64/include/linux
   jvm:
+  - --extra-lib-dirs
+  - /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
+  - --extra-include-dirs
+  - /usr/lib/jvm/java-8-openjdk-amd64/include
+  - --extra-include-dirs
+  - /usr/lib/jvm/java-8-openjdk-amd64/include/linux
+  jvm-streaming:
   - --extra-lib-dirs
   - /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server
   - --extra-include-dirs


### PR DESCRIPTION
These were previously blocked on the inclusion of `streaming`.