### PR TITLE
Re-enable `stack` and add `bindings-uname`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -985,7 +985,8 @@ packages:
         - monad-extras
         - optparse-simple
         - hpack
-        # - stack < 9.9.9  # https://github.com/commercialhaskell/stack/issues/3683
+        - bindings-uname
+        - stack < 9.9.9
 
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
         - th-orphans


### PR DESCRIPTION
Uploaded stack-1.6.1.1 which is compatible with unliftio-0.2.1.0 and smallcheck-1.1.3

This also adds bindings-uname, which is a Stack dependency.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] Some time passed since Hackage upload
- [X] stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
