### PR TITLE
Add snap into stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3116,7 +3116,9 @@ packages:
         - pomaps
 
     "Lucas David Traverso <lucas6246@gmail.com> @ludat":
+        - map-syntax
         - snap
+        - heist
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3115,6 +3115,9 @@ packages:
     "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
         - pomaps
 
+    "Lucas David Traverso <lucas6246@gmail.com> @ludat":
+        - snap
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] Some time passed since Hackage upload
- [ ] stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

This would be my first contribution to stackage and I'm sure there is a good reason why `snap` is not in stackage, and I'd really like to get those issues fixed if it's possible