### PR TITLE
Remove deprecated async-dejafu and dpor packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1918,9 +1918,7 @@ packages:
     "Michael Walker <mike@barrucadu.co.uk> @barrucadu":
         - both
         - concurrency
-        - dpor
         - dejafu
-        - async-dejafu
         - hunit-dejafu
         - tasty-dejafu
         - irc-ctcp


### PR DESCRIPTION
These have both been deprecated for a while in favour of (respectively) `concurrency` and `dejafu`.
