### PR TITLE
Re-add perf and chart-unit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2692,7 +2692,7 @@ packages:
         - numhask-range
         - perf
         - online
-        # - chart-unit # https://github.com/tonyday567/chart-unit/issues/13
+        - chart-unit
 
     "Iphigenia Df <iphydf@gmail.com> @iphydf":
         - data-msgpack

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2690,7 +2690,7 @@ packages:
     "Tony Day <tonyday567@gmail.com> @tonyday567":
         - numhask
         - numhask-range
-        # - perf # https://github.com/tonyday567/perf/issues/2
+        - perf
         - online
         # - chart-unit # https://github.com/tonyday567/chart-unit/issues/13
 


### PR DESCRIPTION
Reversing  https://github.com/fpco/stackage/commit/cfc3f2e89c76b1895c190dc98494bb26e5d26161 and https://github.com/fpco/stackage/commit/87a8bf144048db1962af87d5c69b8573c934f380


Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

