### PR TITLE
Remove constraint preventing persistent-2.7.2 and allowed failure for…

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3142,9 +3142,6 @@ packages:
         # https://github.com/fpco/stackage/issues/2976
         - http-types < 0.10
 
-        # https://github.com/fpco/stackage/issues/3046
-        - persistent < 2.7.2
-
         # https://github.com/fpco/stackage/issues/3143
         - ansi-terminal < 0.8
 
@@ -3584,7 +3581,6 @@ expected-test-failures:
     - shake # Needs ghc on $PATH with some installed haskell packages
     - singletons # Needs ghc on $PATH with som installed haskell packages
     - stack # https://github.com/fpco/stackage/issues/3082
-    - users-persistent # sqlite
     - users-postgresql-simple # PostgreSQL
     - wai-cors # PhantomJS
     - wai-session-postgresql # PostgreSQL


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] ? stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

* persistent-2.7.3 was released which reverts the breaking change accidentally introduced in 2.7.2
* persistent-sqlite-2.6.4 was released which reverts the breaking change accidentally introduced in 2.6.3.2

Closes #3046