### PR TITLE
Add credential-store

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3102,6 +3102,9 @@ packages:
 
     "Alexandre Peyroux <alex@xn--wxa.email> @apeyroux":
         - HSlippyMap
+    
+    "Andrey Sverdlichenko <blaze@ruddy.ru> @rblaze":
+        - credential-store
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [?] stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Can't run tests on travis, since there is no gnome-keyring there. But tests pass on standalone linux installations.