### PR TITLE
Takeover dbus maintainership

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3105,6 +3105,7 @@ packages:
 
     "Andrey Sverdlichenko <blaze@ruddy.ru> @rblaze":
         - credential-store
+        - dbus
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
@@ -3385,7 +3386,6 @@ skipped-tests:
     - MissingH # via testpack https://github.com/jgoerzen/testpack/issues/11
     - chell # via chell-quickcheck
     # - clustering # via RLang-QQ via HList https://github.com/kaizhang/clustering/issues/2 (also sent e-mail to HList maintainer)
-    - dbus # via chell-quickcheck
     - language-ecmascript # via testing-feat
     - options # QuickCheck via chell-quickcheck
     - path # via genvalidity genvalidity-property
@@ -3654,7 +3654,6 @@ expected-test-failures:
     - ListLike # No issue tracker, e-mail sent to maintainer
     - amazonka-core # https://github.com/brendanhay/amazonka/issues/397
     - commutative # https://github.com/athanclark/commutative/issues/4
-    - dbus # 0.10.12 No issue tracker, e-mail sent to maintainer
     - flat # https://github.com/Quid2/flat/issues/1
     - haddock
     - heap # https://github.com/pruvisto/heap/issues/4
@@ -3735,7 +3734,6 @@ expected-benchmark-failures:
     # Compilation failures
     - Frames # https://github.com/acowley/Frames/issues/47
     - cryptohash # https://github.com/vincenthz/hs-cryptohash/pull/43
-    - dbus # No issue tracker, sent e-mail to maintainer
     - ghc-mod # https://github.com/DanielG/ghc-mod/issues/895
     - thyme # https://github.com/liyang/thyme/issues/50
     - xmlgen # https://github.com/skogsbaer/xmlgen/issues/6


### PR DESCRIPTION
I'm current maintainer of dbus package. Last release should have tests and benchmarks running fine, no longer depends on chell packages: https://travis-ci.org/rblaze/haskell-dbus/jobs/323798451

Note: build requires libxml2-dev to be installed (via libxml-sax package).

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
