### PR TITLE
Re-enable tasty-discover.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -195,7 +195,7 @@ packages:
         - List
 
     "Luke Murphy <lukewm@riseup.net> @lwm":
-        # - tasty-discover # tasty via tasty-hedgehog
+        - tasty-discover
         - lentil
 
     "Marco Zocca @ocramz":


### PR DESCRIPTION
Blocking issue resolved (for now) in https://github.com/lwm/tasty-discover/pull/132.

---

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] Some time passed since Hackage upload (**probably might need a rebuild**).
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
