### PR TITLE
Reenable building sparkle Haddocks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3777,9 +3777,6 @@ expected-haddock-failures:
     # Runs out of memory
     - store
 
-    # https://github.com/tweag/sparkle/issues/131
-    - sparkle
-
 # end of expected-haddock-failures
 
 # For packages with haddock issues


### PR DESCRIPTION
Upstream ticket https://github.com/tweag/sparkle/issues/131 was
resolved.