### PR TITLE
Add euler-tour-tree and rss-conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1736,6 +1736,7 @@ packages:
         - dublincore-xml-conduit
         - euler-tour-tree
         - opml-conduit
+        - rss-conduit
         - timerep
         - xml-conduit-parse
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1734,6 +1734,7 @@ packages:
         - atom-conduit
         - conduit-parse
         - dublincore-xml-conduit
+        - euler-tour-tree
         - opml-conduit
         - timerep
         - xml-conduit-parse


### PR DESCRIPTION
`rss-conduit` had been removed from stackage due to `hlint` test breaking regularly. This test is now disabled by default.
`euler-tour-tree` is a brand new package.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
