### PR TITLE
Allow hindent since new release (5.2.4) are available on hackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -497,7 +497,7 @@ packages:
         - present
         - pure-io
         - sourcemap
-        # - hindent # https://github.com/commercialhaskell/hindent/issues/478
+        - hindent
         - descriptive
         - wrap
         - path


### PR DESCRIPTION
The hindent-5.2.5 is available on hackage and is compatible with haskell-src-exts-1.20.x.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
