### PR TITLE
Added pomaps to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3109,6 +3109,9 @@ packages:
     "Andrey Sverdlichenko <blaze@ruddy.ru> @rblaze":
         - credential-store
         - dbus
+        
+    "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
+        - pomaps
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
I'm willing to maintain [`pomaps`](https://hackage.haskell.org/package/pomaps)  for the foreseeable future. The testsuite needs `ChasingBottoms` (a non-stackage dependency), though. I'm not sure this will pass CI, at least it doesn't as per the pro-active checks listed in `MAINTAINERS.md`.

----

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
