### PR TITLE
Re-enable compressed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -528,6 +528,7 @@ packages:
         - comonads-fd
         - comonad-transformers
         - compensated
+        - compressed
         - concurrent-supply
         - constraints
         - contravariant


### PR DESCRIPTION
A new release ([`compressed-3.11`](https://hackage.haskell.org/package/compressed-3.11)) was just uploaded to Hackage with appropriate version bounds.

Chips away at https://github.com/fpco/stackage/issues/3048.