### PR TITLE
Add re2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3115,6 +3115,7 @@ packages:
     "Andrey Sverdlichenko <blaze@ruddy.ru> @rblaze":
         - credential-store
         - dbus
+        - re2
 
     "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
         - pomaps

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -99,6 +99,7 @@ apt-get install -y \
     libpango1.0-dev \
     libpcap0.8-dev \
     libpq-dev \
+    libre2-dev \
     libsdl1.2-dev \
     libsdl2-dev \
     libsdl2-gfx-dev \


### PR DESCRIPTION
Add re2-0.2 library. Note that It requires libre2-dev C library to build. Travis builds were successful: https://travis-ci.org/rblaze/haskell-re2/builds/326910011

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
