### PR TITLE
re-enable hledger packages, add shelltestrunner

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -901,13 +901,11 @@ packages:
         - uri-encode
 
     "Simon Michael <simon@joyful.com> @simonmichael":
-        # haskell-src-exts via here
-        # - hledger
-        # - hledger-lib
-        # - hledger-ui
-        # - hledger-web
-        # - hledger-api # haskell-src-exts via servant-swagger
-
+        - hledger
+        - hledger-lib
+        - hledger-ui
+        - hledger-web
+        - hledger-api
         - quickbench
         - regex-compat-tdfa
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -908,6 +908,7 @@ packages:
         - hledger-api
         - quickbench
         - regex-compat-tdfa
+        - shelltestrunner
 
     "Mihai Maruseac <mihai.maruseac@gmail.com> @mihaimaruseac":
         - io-manager


### PR DESCRIPTION
They got quietly removed 3 weeks ago by #3093. 
The current 1.5 versions all seem to build fine with haskell-src-exts-1.20.1.
