### PR TITLE
Add transformers-either

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3126,6 +3126,9 @@ packages:
 
     "Alexey Kotlyarov <akotlyarov@seek.com.au> @koterpillar":
         - serverless-haskell
+        
+    "Tim Humphries <tim+stackage@utf8.me> @thumphries":
+        - transformers-either
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
As per https://github.com/tmcgilchrist/transformers-either/issues/1

Local build fails on the Cassava flag stuff but `transformers-either` is almost certainly fine, it's small and simple

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] Some time passed since Hackage upload
- [X] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
