### PR TITLE
Add o-clock

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2977,6 +2977,7 @@ packages:
     "Serokell <hi@serokell.io> @serokell":
         # - importify # haskell-src-exts via haskell-names
         - log-warper
+        - o-clock
         - universum
 
     "Lorenz Moesenlechner <moesenle@gmail.com> @moesenle":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Unfortunately, `stack init --resolver nightly --solver` command fails for `o-clock`. Though `o-clock` still can be built with `stack`. Here is `stack.yaml` which is used for building `o-clock` package:

* https://github.com/serokell/o-clock/blob/master/stack.yaml

Most likely, if tests and benchmarks are disabled, this project can be built without any problems. Please, tell me, what I need to change or should I just wait until needed packages become available. I would love to help with any issues!