### PR TITLE
Skip dlist-nonempty tests/benchmarks and splitmix benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3514,6 +3514,7 @@ skipped-tests:
     - tdigest
     - these
     - time-parsers
+    - dlist-nonempty # QuickCheck2.11
 
     # Uncategorized, please categorize!
     - hackage-security # Cabal 2.0
@@ -3914,6 +3915,10 @@ skipped-benchmarks:
     - ed25519 # Criterion
 
     - fmt # haskell-src-exts via interpolate
+
+    # @phadej
+    - dlist-nonempty # criterion-1.3
+    - splitmix# # criterion-1.3
 
 # end of skipped-benchmarks
 


### PR DESCRIPTION
I will enable them after making GHC-8.4 compatible releases

---

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
