### PR TITLE
Restore `bench`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -727,7 +727,7 @@ packages:
         - turtle
         - foldl
         - morte
-        # - bench # turtle 1.5
+        - bench
         - dhall
         - dhall-bash
         - dhall-json


### PR DESCRIPTION
The latest release of `bench` supports the most recent version of its
dependencies (including `turtle`)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload (12 hours)
- [x] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
