### PR TITLE
update cabal-format-version to 2.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3,7 +3,7 @@ ghc-major-version: "8.2"
 # This affects which version of the Cabal file format we allow. We
 # should ensure that this is always no greater than the version
 # supported by the most recent cabal-install and Stack releases.
-cabal-format-version: "1.24"
+cabal-format-version: "2.0"
 
 # Constraints for brand new builds
 packages:


### PR DESCRIPTION
As I understand it, all of our tools are now ready to handle this.
Unblocks #3207, and allows us to lift a few more constraints, like the one on haddock-library.