### PR TITLE
Re-enable invertible

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2808,7 +2808,7 @@ packages:
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed
-        # - invertible # build failure https://github.com/dylex/invertible/issues/3
+        - invertible
         - ztail
 
     "Louis Pan <louis@pan.me> @louispan":


### PR DESCRIPTION
0.2.0.3 fixes build with semigroupoids-5.2.2

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have succesfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
