### PR TITLE
Remove constraint on terminal-progress-bar.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3259,9 +3259,6 @@ packages:
         # https://github.com/silkapp/rest/issues/157
         - rest-client < 0.5.2.1
 
-        # https://github.com/fpco/stackage/issues/3230
-        - terminal-progress-bar < 0.1.2
-
         # https://github.com/fpco/stackage/issues/3233
         - adjunctions < 4.4
 
@@ -3467,7 +3464,6 @@ skipped-tests:
     - printcess # QuickCheck 2.10
     - superbuffer # QuickCheck 2.10
     - tar # tasty-quickcheck
-    - terminal-progress-bar # HUnit 1.6, see also https://github.com/fpco/stackage/issues/3230
     - text # HUnit 1.6
     - text-short # tasty-quickcheck
     - vector # QuickCheck 2.10


### PR DESCRIPTION
Also reverts 771100ee137d397d0c15da732a631fb82869eec3.

This closes https://github.com/fpco/stackage/issues/3230.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
