### PR TITLE
Return haskell-names back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2627,8 +2627,7 @@ packages:
         - language-fortran
 
     "Philipp Schuster <phischu3000@gmail.com> @phischu":
-        []
-        # - haskell-names # haskell-src-exts
+        - haskell-names
 
     "Shao Cheng <astrohavoc@gmail.com> @TerrorJack":
         - cabal-toolkit


### PR DESCRIPTION
It was removed because of `haskell-src-exts` problem. `haskell-names-0.9.1` fixed this.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
