### PR TITLE
adding hamilton back in to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3249,9 +3249,6 @@ packages:
         # https://github.com/fpco/stackage/issues/3211
         - pandoc-citeproc < 0.14
 
-        # https://github.com/mstksg/hamilton/issues/4
-        - hamilton < 0
-
         # https://github.com/nikita-volkov/rebase/issues/11
         - rebase < 0
         - hasql-migration < 0


### PR DESCRIPTION
https://github.com/mstksg/hamilton/4 has been fixed in the latest version, so just submitting a change to put it back into the nightlies :)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
