### PR TITLE
Remove ‘data-check’

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2106,7 +2106,6 @@ packages:
         - JuicyPixels-extra
         - identicon
         - pagination
-        - data-check
         - text-metrics
         - tagged-identity
         - req


### PR DESCRIPTION
The package has been deprecated and is no longer supported. I seriously doubt it's used by anyone, so it's fairly safe to drop it.

Checklist: **not applicable**.