### PR TITLE
Cleanup Kmett packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -540,6 +540,8 @@ packages:
     "Edward Kmett <ekmett@gmail.com> @ekmett":
         - ad
         - adjunctions
+        - algebra
+        - ansi-wl-pprint
         - approximate
         - bifunctors
         - bits
@@ -547,8 +549,6 @@ packages:
         - bytes
         - charset
         - comonad
-        - comonads-fd
-        - comonad-transformers
         - compensated
         - compressed
         - concurrent-supply
@@ -560,17 +560,26 @@ packages:
         - eq
         - ersatz
         - exceptions
+        - fixed
+        - folds
         - free
+        - gc
+        - gl
         - graphs
-        - groupoids
+        - half
         - heaps
+        - hybrid-vectors
         - hyperloglog
         - hyphenation
         - integration
+        - intern
         - intervals
         - kan-extensions
+        - keys
         - lca
         - lens
+        - lens-action
+        - lens-aeson
         - lens-properties
         - linear
         - linear-accelerate
@@ -578,17 +587,16 @@ packages:
         - machines
         - monadic-arrays
         - monad-products
-        - monad-products
         - monad-st
         - mtl
         - nats
         - numeric-extras
         - parsers
         - pointed
-        - prelude-extras
-        - profunctor-extras
         - profunctors
         - promises
+        - rcu
+        - recursion-schemes
         - reducers
         - reflection
         - semigroupoid-extras
@@ -596,6 +604,7 @@ packages:
         - semigroups
         - speculation
         - streams
+        - structs
         - tagged
         - trifecta
         - unique
@@ -604,10 +613,6 @@ packages:
         - wl-pprint-extras
         - wl-pprint-terminfo
         - zippers
-        - fixed
-        - half
-        - gl
-        - lens-aeson
         - zlib-lens
 
     "Andrew Farmer <afarmer@ittc.ku.edu> @xich":


### PR DESCRIPTION
This accomplishes the following:

* Re-alphabetize some packages that were out-of-order
* Remove the deprecated packages `comonads-fd`, `comonad-transformers`, `groupoids`, `prelude-extras`, and `profunctor-extras`
* Remove a duplicate entry for `monad-products`
* Add some packages which I thought were already in this list, but weren't: `algebra`, `ansi-wl-pprint`, `fold`, `gc`, `hybrid-vectors`, `intern`, `keys`, `lens-action`, `rcu`, `recursion-schemes`, and `structs`