### PR TITLE
Remove upper bound on distributed-closure.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3359,9 +3359,6 @@ packages:
         # https://github.com/fpco/stackage/issues/3269
         - unordered-containers < 0.2.9
 
-        # https://github.com/tweag/sparkle/issues/137
-        - distributed-closure < 0.3.5
-
         # https://github.com/fpco/stackage/issues/3270
         - brick < 0.34
 


### PR DESCRIPTION
sparkle now builds with the latest distributed-closure.
