### PR TITLE
Enable language-puppet package again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2100,7 +2100,7 @@ packages:
         - strict-base-types
         - withdependencies
         - hruby
-        # - language-puppet # servant 0.12
+        - language-puppet
         - tar-conduit
 
     "Mark Karpov <markkarpov92@gmail.com> @mrkkrp":


### PR DESCRIPTION
`language-puppet` upper bound has been removed in `v1.3.14`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] 8 hours passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
