### PR TITLE
Remove ‘plan-b’

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2110,7 +2110,6 @@ packages:
         - slug
         - path-io
         - hspec-megaparsec
-        - plan-b
         - zip
         - JuicyPixels-extra
         - identicon


### PR DESCRIPTION
The package is deprecated and no longer supported. Please merge when we have `zip-1.0.0`, older versions of `zip` depend on ‘plan-b’.

Checklist: **not applicable**.