### PR TITLE
Allow recent versions of hpack.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3279,9 +3279,6 @@ packages:
         - free < 5
         - ChannelT == 0.0.0.4
 
-        # https://github.com/fpco/stackage/issues/3237
-        - hpack < 0.23
-
         # https://github.com/fpco/stackage/issues/3238
         - lens < 4.16
 


### PR DESCRIPTION
Closes https://github.com/fpco/stackage/issues/3237.