### PR TITLE
added hmatrix-vector-sized and hmatrix-backprop

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1692,6 +1692,8 @@ packages:
         - backprop
         - configurator-export
         - hamilton
+        - hmatrix-backprop
+        - hmatrix-vector-sized
         - one-liner-instances
         - prompt
         - tagged-binary


### PR DESCRIPTION
hmatrix-vector-sized and hmatrix-backprop to stackage

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
