### PR TITLE
Add new packages massiv and massiv-io

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2791,6 +2791,8 @@ packages:
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
         - wai-middleware-auth
         - hip
+        - massiv
+        - massiv-io
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
         - hledger-iadd


### PR DESCRIPTION
I'd like to add these newly released packages [massiv](https://hackage.haskell.org/package/massiv) and [massiv-io](https://hackage.haskell.org/package/massiv-io). More info on the packages is on the github page [github.com/lehins/massiv](https://github.com/lehins/massiv)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
