### PR TITLE
tasty-hedgehog made a release. Unblock packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -215,7 +215,7 @@ packages:
         - List
 
     "Luke Murphy <lukewm@riseup.net> @lwm":
-        # - tasty-discover # tasty via tasty-hedgehog
+        - tasty-discover
         - lentil
 
     "Marco Zocca @ocramz":
@@ -2405,7 +2405,7 @@ packages:
 
     "Ozgun Ataman ozgun.ataman@soostone.com @ozataman":
         - string-conv
-        # - rng-utils # tasty via tasty-hedgehog
+        - rng-utils
         - ua-parser
         - hs-GeoIP
         - retry


### PR DESCRIPTION
Refs:
  - https://github.com/qfpl/tasty-hedgehog/issues/4
  - https://github.com/fpco/stackage/issues/2995
  - https://github.com/fpco/stackage/pull/3140/files

I proofed this change only for `tasty-discover` in [this build](https://travis-ci.org/lwm/tasty-discover/jobs/345880592).

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
