### PR TITLE
resolved: upper bound for tsani/servant-github-webhook#9

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3375,9 +3375,6 @@ packages:
         # https://github.com/fpco/stackage/issues/3278
         - lifted-async < 0.10
 
-        # https://github.com/tsani/servant-github-webhook/issues/9
-        - servant-github-webhook < 0.4
-
         # https://github.com/fpco/stackage/issues/3274
         - cryptonite < 0.25
 


### PR DESCRIPTION
Now that onrock-eng/github-webhooks#4 has been closed and `github-webhooks` is on stackage, servant-github-webhook 0.4.0.0 builds with stackage nightly, without using `extra-deps`.
Once this is merged, I'll close tsani/servant-github-webhook#9.