### PR TITLE
re-add diagrams-rasterific

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -654,6 +654,7 @@ packages:
         - diagrams-contrib
         - diagrams-core
         - diagrams-lib
+        - diagrams-rasterific
         - diagrams-svg
         - force-layout
         - haxr


### PR DESCRIPTION
It used to be disabled because of constraints on optparse-applicative, compare #2569 and #3048. These have been relaxed in the meantime: https://github.com/diagrams/diagrams-rasterific/commit/f7f289d731eaf9b5cc6d13fad4666e1b1d3c9334

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload (updated Wed Jan 10 21:29:07 UTC 2018)
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
