### PR TITLE
Remove github-webhooks as an expected failure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3895,7 +3895,6 @@ expected-test-failures:
     - cubicbezier # https://github.com/kuribas/cubicbezier/issues/3
     - ghc-events # https://github.com/haskell/ghc-events/issues/9
     - ghc-syb-utils # https://github.com/nominolo/ghc-syb/issues/18
-    - github-webhooks # https://github.com/fpco/stackage/pull/3322#issuecomment-369536583
     - graylog # 0.1.0.1 https://github.com/fpco/stackage/pull/1254
     - matplotlib # https://github.com/fpco/stackage/issues/2365
     - rematch # No issue tracker, sent e-mail to maintainer https://github.com/fpco/stackage/issues/376


### PR DESCRIPTION
https://github.com/fpco/stackage/pull/3322#issuecomment-369536583

Since 0.9.1 we now correctly include the fixtures with the source distribution