### PR TITLE
Restore `pipes-extras`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -758,7 +758,7 @@ packages:
     "Gabriel Gonzalez <Gabriel439@gmail.com> @Gabriel439":
         - optparse-generic
         - pipes
-        # - pipes-extras # lens 4.16
+        - pipes-extras
         - pipes-parse
         - pipes-concurrency
         - pipes-safe
@@ -2857,9 +2857,9 @@ packages:
         - glazier-pipes
         - javascript-extras
         - l10n
-        # - pipes-category # lens 4.16 via pipes-extras
-        # - pipes-fluid # lens 4.16 via pipes-extras
-        # - pipes-misc # lens 4.16 via pipes-extras
+        - pipes-category
+        - pipes-fluid
+        - pipes-misc
         - stm-extras
 
     "Siniša Biđin <sinisa@bidin.eu> @sbidin":


### PR DESCRIPTION
`pipes-extras-1.0.13` now builds against `lens-4.16`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
