### PR TITLE
Re-added pandoc, pandoc-citeproc.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2406,8 +2406,8 @@ packages:
         - pandoc-types < 1.19 || > 1.19 # Accidental upload, see: https://github.com/fpco/stackage/issues/2223
         - zip-archive
         - doctemplates
-        # - pandoc # http-types 0.12
-        # - pandoc-citeproc # http-types 0.12 via pandoc
+        - pandoc
+        - pandoc-citeproc
 
     "Karun Ramakrishnan <karun012@gmail.com> @karun012":
         - doctest-discover


### PR DESCRIPTION
I have bumped the upper bound for http-types on Hackage for pandoc 2.1.2, so this should unblock both pandoc and pandoc-citeproc.
