### PR TITLE
re-add hledger-web

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -947,7 +947,7 @@ packages:
         - hledger
         - hledger-lib
         - hledger-ui
-        # - hledger-web # https://github.com/simonmichael/hledger/issues/717
+        - hledger-web
         - hledger-api
         - quickbench
         - regex-compat-tdfa


### PR DESCRIPTION
hledger-web 1.5.1 builds with yesod 1.6 
(cf https://github.com/simonmichael/hledger/issues/717)
