### PR TITLE
Add conduit-algorithms back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2990,7 +2990,7 @@ packages:
 
     "Luis Pedro Coelho <luis@luispedro.org> @luispedro":
         - safeio
-        # - conduit-algorithms # https://github.com/luispedro/conduit-algorithms/issues/6
+        - conduit-algorithms
 
     "Alex Biehl <alexbiehl@gmail.com> @alexbiehl":
         - haddock-library
@@ -3668,8 +3668,6 @@ skipped-tests:
     - hpack # haskell-src-exts via interpolate
 
     - ihaskell # haskell-src-exts via here
-
-    - conduit-algorithms # https://github.com/luispedro/conduit-algorithms/issues/3
 
 # end of skipped-tests
 


### PR DESCRIPTION
Issues blocking it are fixed in newer release

Checklist:
- [x]  Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
