### PR TITLE
Restore `dhall` and reverse dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -768,11 +768,11 @@ packages:
         - foldl
         - morte
         - bench
-        # - dhall # ansi-terminal-0.8
-        # - dhall-bash # via dhall
-        # - dhall-json # via dhall
+        - dhall
+        - dhall-bash
+        - dhall-json
         # - dhall-nix # deriving-compat via hnix
-        # - dhall-text # via dhall
+        - dhall-text
 
     "Andrew Thaddeus Martin <andrew.thaddeus@gmail.com> @andrewthad":
         - yesod-table


### PR DESCRIPTION
The latest version of `dhall` builds against the latest version of `ansi-terminal`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
