### PR TITLE
added: yesod-recaptcha2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2882,7 +2882,7 @@ packages:
         - string-transform
         - uniq-deep
         - yesod-form-bootstrap4
-        # - yesod-recaptcha2 # https://github.com/ncaq/yesod-recaptcha2/issues/2
+        - yesod-recaptcha2
 
     "Andrei Barbu <andrei@0xab.com> @abarbu":
         - nondeterminism


### PR DESCRIPTION
I fixed yesod 1.6 build.
[yesod-recaptcha2-0.2.3 build failure with yesod-1.6 · Issue #2 · ncaq/yesod-recaptcha2](https://github.com/ncaq/yesod-recaptcha2/issues/2)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
