### PR TITLE
Install LLVM 6.0 in docker image and reenable llvm-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3755,7 +3755,6 @@ packages:
         - pipes-fluid < 0 # GHC 8.4 via lifted-async
         - quickcheck-state-machine < 0 # GHC 8.4 via lifted-async
         - shelly < 0 # GHC 8.4 via lifted-async
-        - llvm-hs < 0 # GHC 8.4 via llvm-hs-pure
         - lzma-conduit < 0 # GHC 8.4 via lzma
         - zim-parser < 0 # GHC 8.4 via lzma
         - heist < 0 # GHC 8.4 via map-syntax

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -156,11 +156,17 @@ curl -sSL https://get.haskellstack.org/ | sh
 # Put documentation where we expect it
 mv /opt/ghc/$GHCVER/share/doc/ghc-$GHCVER/ /opt/ghc/$GHCVER/share/doc/ghc
 
-# llvm-5.0 for llvm-hs (separate since it needs wget)
+# llvm-5.0 for GHC (separate since it needs wget)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" \
     && apt-get update \
     && apt-get install -y llvm-5.0
+
+# llvm-6.0 for llvm-hs (separate since it needs wget)
+wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" \
+    && apt-get update \
+    && apt-get install -y llvm-6.0
 
 # Buggy versions of ld.bfd fail to link some Haskell packages:
 # https://sourceware.org/bugzilla/show_bug.cgi?id=17689. Gold is


### PR DESCRIPTION
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] I’ve built the docker image and built `llvm-hs-pure-6.0.0` and `llvm-hs-6.0.0` (fetched via `stack unpack`, for `llvm-hs-6.0.0` I added `llvm-hs-pure-6.0.0` to `extra-deps`) in the docker image using `nightly-2018-03-14` and ran the tests of both.
