### PR TITLE
build-constraints: json-autotype has updates constraints on Hackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3482,7 +3482,6 @@ packages:
         - http-media < 0 # GHC 8.4 via base-4.11.0.0
         - hxt-pickle-utils < 0 # GHC 8.4 via base-4.11.0.0
         - indexed-list-literals < 0 # GHC 8.4 via base-4.11.0.0
-        - json-autotype < 0 # GHC 8.4 via base-4.11.0.0
         - json-stream < 0 # GHC 8.4 via base-4.11.0.0
         - kraken < 0 # GHC 8.4 via base-4.11.0.0
         - lackey < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Revision 2 of json-autotype-1.0.18 should build fine with GHC 8.4.x.