### PR TITLE
timezone-olson now builds with 8.4.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3344,7 +3344,6 @@ packages:
         - skeletons < 0 # build failure with GHC 8.4
         - sql-words < 0 # build failure with GHC 8.4
         - timespan < 0 # build failure with GHC 8.4
-        - timezone-olson < 0 # build failure with GHC 8.4
         - tinytemplate < 0 # build failure with GHC 8.4
         - transient < 0 # build failure with GHC 8.4
         - tuple < 0 # build failure with GHC 8.4
@@ -4955,10 +4954,6 @@ package-flags:
 
     functor-classes-compat:
         containers: true
-
-    timezone-series:
-        time_1_6_and_1_7: false
-        time_pre_1_6: false
 
     mintty:
         win32-2-5: true


### PR DESCRIPTION
Updated timezone-series to work with time >= 1.9.1, and timezone-olson to work with GHC >= 8.4.

Checklist:
- [ x] Meaningful commit message - please not `Update build-constraints.yml`
- [ x] Some time passed since Hackage upload
- [  ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

They build fine with cabal on my machine, and in Github travis-ci, with GHC 8.4.1. Only trivial changes were made. So I believe they'll work on stackage too. And many people need these packages.

I cannot build *anything* with the 8.4.1 nightlies on my machine, those nightlies are broken for me currently.