### PR TITLE
Re-enabling Rasterific

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -671,7 +671,7 @@ packages:
     "Vincent Berthoux <vincent.berthoux@gmail.com> @Twinside":
         - JuicyPixels
         - FontyFruity
-        # - Rasterific # build failure with GHC 8.4 https://github.com/Twinside/Rasterific/issues/37
+        - Rasterific
         - svg-tree
         - rasterific-svg
         - asciidiagram
@@ -3268,7 +3268,6 @@ packages:
     "Build failure with GHC 8.4":
         - Chart < 0 # build failure with GHC 8.4 https://github.com/timbod7/haskell-chart/issues/181
         - PSQueue < 0 # build failure with GHC 8.4 (nowhere to report, it's ancient just let it die)
-        - Rasterific < 0 # build failure with GHC 8.4 https://github.com/Twinside/Rasterific/issues/37
         - b9 < 0 # build failure with GHC 8.4 https://github.com/sheyll/b9-vm-image-builder/issues/4
         - cabal-rpm < 0 # build failure with GHC 8.4 https://github.com/juhp/cabal-rpm/issues/55
         - conduit-parse < 0 # build failure with GHC 8.4 https://github.com/k0ral/conduit-parse/issues/3


### PR DESCRIPTION
Semigroup instances has been added, and uploaded to Hackage

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
