### PR TITLE
build-constraints.yaml: add cabal2spec to my package list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2080,6 +2080,7 @@ packages:
 
     "Peter Simons <simons@cryp.to> @peti":
         - cabal2nix
+        - cabal2spec
         - distribution-nixpkgs
         - funcmp
         - hackage-db


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I ran those commands, but got the following error, which makes no sense to me:

    The following packages specified by flags or options are not found: persistent-sqlite

I don't see how my package would depend on persistent-sqlite. 