### PR TITLE
Re-add hasty-hamiltonian, declarative.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9,7 +9,7 @@ cabal-format-version: "2.0"
 packages:
     "Fraser Murray <fraser.m.murray@gmail.com @intolerable":
         - stitch
-        
+
     "Yusent Chig <yusent@protonmail.com> @yusent":
         []
         # - yesod-auth-bcryptdb # conduit 1.3, yesod 1.6
@@ -2175,8 +2175,8 @@ packages:
         - mcmc-types
         - mighty-metropolis
         - speedy-slice
-        # - hasty-hamiltonian # https://github.com/jtobin/hasty-hamiltonian/issues/2
-        # - declarative # via hasty-hamiltonian
+        - hasty-hamiltonian
+        - declarative
         - sampling
         - flat-mcmc
 
@@ -3234,7 +3234,7 @@ packages:
     "Avi Press <mail@avi.press> @aviaviavi":
         - curl-runnings
         - cryptocompare
-        
+
     "Jack Kiefer <jack.c.kiefer@gmail.com> @JackKiefer":
         - herms
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

**Note**: for some reason `mcmc-types`, a dependency for both of these libraries, isn't being included in nightly, so I can't execute the last step in the checklist above.  It seems to be excluded via the line in build-constraints [here](https://github.com/fpco/stackage/blob/6b60051a88c9f9c0ef4f479b8bd20e4cfc59c80f/build-constraints.yaml#L4063).  

When running against nightly-2018-03-12 -- the last day `mcmc-types` was included in nightly -- everything works fine.