### PR TITLE
Add stratosphere back to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2559,7 +2559,7 @@ packages:
         - eventful-sql-common
         - eventful-sqlite
         - eventful-test-helpers
-        # - stratosphere # build failure with GHC 8.4 https://github.com/frontrowed/stratosphere/issues/81
+        - stratosphere
         - sum-type-boilerplate
 
     "Iñaki García Etxebarria <garetxe@gmail.com> @garetxe":


### PR DESCRIPTION
I fixed GHC 8.4.1 compatibility with https://github.com/frontrowed/stratosphere/pull/82

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] Some time passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
