### PR TITLE
Re-enable arithmoi for GHC 8.4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3422,7 +3422,6 @@ packages:
         - pinch < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - pthread < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - yi-rope < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - arithmoi < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - streaming-bytestring < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - HStringTemplate < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - csv-conduit < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
