### PR TITLE
Unblock monad-logger-prefix

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3644,7 +3644,6 @@ packages:
         - threepenny-gui < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - tz < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - web-routes-th < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - monad-logger-prefix < 0 # GHC 8.4 via transformers-0.5.5.0
         - morte < 0 # GHC 8.4 via Earley
         - stm-supply < 0 # GHC 8.4 via Unique
         - linear-accelerate < 0 # GHC 8.4 via accelerate


### PR DESCRIPTION
Fixed in 0.1.9

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
