### PR TITLE
Unblock `ghc-parser`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3773,7 +3773,6 @@ packages:
         - wavefront < 0 # GHC 8.4 via base-4.11.0.0
         - apply-refact < 0 # GHC 8.4 via ghc-8.4.1
         - brittany < 0 # GHC 8.4 via ghc-8.4.1
-        - ghc-parser < 0 # GHC 8.4 via ghc-8.4.1
         - haskell-tools-prettyprint < 0 # GHC 8.4 via ghc-8.4.1
         - haskell-tools-rewrite < 0 # GHC 8.4 via ghc-8.4.1
         - inline-java < 0 # GHC 8.4 via ghc-8.4.1


### PR DESCRIPTION
Unblock `ghc-parser`.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
