### PR TITLE
Re-re enable Rasterific

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -670,7 +670,7 @@ packages:
     "Vincent Berthoux <vincent.berthoux@gmail.com> @Twinside":
         - JuicyPixels
         - FontyFruity
-        # - Rasterific # build failure with ghc 8.4 https://github.com/Twinside/Rasterific/issues/38
+        - Rasterific
         - svg-tree
         - rasterific-svg
         - asciidiagram
@@ -3272,7 +3272,6 @@ packages:
         - Chart < 0 # build failure with GHC 8.4 https://github.com/timbod7/haskell-chart/issues/181
         - OneTuple < 0 # build failure with GHC 8.4 https://github.com/fpco/stackage/pull/3359
         - PSQueue < 0 # build failure with GHC 8.4 (nowhere to report, it's ancient just let it die)
-        - Rasterific < 0 # build failure with GHC 8.4 https://github.com/Twinside/Rasterific/issues/38
         - TypeCompose < 0 # build failure with GHC 8.4 https://github.com/conal/TypeCompose/issues/6
         - b9 < 0 # build failure with GHC 8.4 https://github.com/sheyll/b9-vm-image-builder/issues/4
         - biocore < 0 # build failure with GHC 8.4 https://github.com/fpco/stackage/pull/3359
@@ -3504,7 +3503,6 @@ packages:
         - ignore < 0 # GHC 8.4 via HTF
         - large-hashable < 0 # GHC 8.4 via HTF
         - haxr < 0 # GHC 8.4 via HaXml
-        - rasterific-svg < 0 # GHC 8.4 via Rasterific
         - Spock < 0 # GHC 8.4 via Spock-core
         - pell < 0 # GHC 8.4 via arithmoi
         - biopsl < 0 # GHC 8.4 via biocore


### PR DESCRIPTION
This one managed to build with latest stack on windows and compile against GHC 8.4.1

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
