### PR TITLE
build-constraints.yaml: cabal2nix 2.9.1 compiles fine in nightly-2018-03-17

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3449,7 +3449,6 @@ packages:
         - attoparsec-ip < 0 # DependencyFailed (PackageName "ip")
         - attoparsec-uri < 0 # DependencyFailed (PackageName "attoparsec-ip")
         - binary-tagged < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - cabal2nix < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cli < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - concurrent-extra < 0 # BuildFailureException Process exited with ExitFailure 1: dist/build/test-concurrent-extra/test-concurrent-extra
         - crackNum < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build


### PR DESCRIPTION
See also https://travis-ci.org/NixOS/cabal2nix/builds/354683580.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
