### PR TITLE
Confirmed compatibility of crypto-enigma 0.0.2.11 with GHC 8.4.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3492,7 +3492,7 @@ packages:
         - compact < 0 # GHC 8.4 via base-4.11.0.0
         - country < 0 # GHC 8.4 via base-4.11.0.0
         - crypt-sha512 < 0 # GHC 8.4 via base-4.11.0.0
-        - crypto-enigma < 0 # GHC 8.4 via base-4.11.0.0
+        # - crypto-enigma < 0 # GHC 8.4 via base-4.11.0.0
         - cryptohash-sha512 < 0 # GHC 8.4 via base-4.11.0.0
         - css-syntax < 0 # GHC 8.4 via base-4.11.0.0
         - dictionaries < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
