### PR TITLE
unblock configuration-tools

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1734,7 +1734,7 @@ packages:
 
     "Lars Kuhtz <lakuhtz@gmail.com> @larskuhtz":
         - wai-cors
-        # - configuration-tools # build failure with GHC 8.4 ttps://github.com/alephcloud/hs-configuration-tools/issues/65
+        - configuration-tools
 
     "Sam Rijs <srijs@airpost.net> @srijs":
         - ndjson-conduit
@@ -3277,7 +3277,6 @@ packages:
         - b9 < 0 # build failure with GHC 8.4 https://github.com/sheyll/b9-vm-image-builder/issues/4
         - biocore < 0 # build failure with GHC 8.4 https://github.com/fpco/stackage/pull/3359
         - cabal-rpm < 0 # build failure with GHC 8.4 https://github.com/juhp/cabal-rpm/issues/55
-        - configuration-tools < 0 # build failure with GHC 8.4 https://github.com/alephcloud/hs-configuration-tools/issues/65
         - dom-parser < 0 # build failure with GHC 8.4 https://github.com/typeable/dom-parser/issues/10
         - enummapset < 0 # build failure with GHC 8.4 https://github.com/michalt/enummapset/issues/11
         - fb < 0 # build failure with GHC 8.4 https://github.com/psibi/fb/issues/3


### PR DESCRIPTION
version 0.3.1 builds with GHC-8.4.1 and Cabal-2.2 (https://github.com/alephcloud/hs-configuration-tools/issues/65)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
