### PR TITLE
Add al to the build-constraints.yaml.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -959,6 +959,7 @@ packages:
         - io-manager
 
     "Dimitri Sabadie <dimitri.sabadie@gmail.com> @phaazon":
+        - al
         - event
         - hid
         - monad-journal


### PR DESCRIPTION
I tried to have al in stackage years ago but there was an issue with
pkg-config on Ubuntu. If that fails again, I’d love peeps to see how we
can fix that problem.

---

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
