### PR TITLE
Add text-builder

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4432,6 +4432,7 @@ skipped-tests:
     - refined
     - slave-thread
     - stm-containers
+    - text-builder
     # @ivan-m https://github.com/fpco/stackage/issues/2538#issuecomment-307290070
     - fgl
     - fgl-arbitrary


### PR DESCRIPTION
Got Nikita's consent to add `text-builder` to Stackage https://twitter.com/NikitaYVolkov/status/974904328422068224

Like Nikita's other packages, the constraints on the test suite / benchmark don't line up with Stackage, but the package itself builds fine.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
