### PR TITLE
 put back cisco-spart-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3073,7 +3073,7 @@ packages:
     "Naoto Shimazaki <naoto.shimazaki@gmail.com> @igy":
         - thread-hierarchy
         - bitset-word8
-        # - cisco-spark-api # https://github.com/nshimaza/cisco-spark-api/issues/1
+        - cisco-spark-api
 
     "Deni Bertovic <deni@denibertovic.com> @denibertovic & James Parker <dev@jamesparker.me> @jprider63":
         - docker


### PR DESCRIPTION
Please put back cisco-spart-api.

- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
