### PR TITLE
re-enable `ghc-typelits-*` type-checker plugins

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3391,7 +3391,6 @@ packages:
         - envparse < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - fmt < 0 # DependencyFailed (PackageName "text-format")
         - getopt-generics < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - ghc-typelits-natnormalise < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - ghcjs-base-stub < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - ginger < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - glob-posix < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
@@ -3782,7 +3781,6 @@ packages:
         - classyplate < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - czipwith < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - data-accessor-template < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - ghc-typelits-knownnat < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - happstack-server < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - haskell-tools-ast < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - haskell-tools-backend-ghc < 0 # GHC 8.4 via template-haskell-2.13.0.0
@@ -3845,7 +3843,6 @@ packages:
         - download < 0 # GHC 8.4 via feed
         - json-schema < 0 # GHC 8.4 via generic-aeson
         - hint < 0 # GHC 8.4 via ghc-8.4.1
-        - ghc-typelits-extra < 0 # GHC 8.4 via ghc-typelits-knownnat
         - hmatrix-backprop < 0 # GHC 8.4 via ghc-typelits-knownnat
         - hmatrix-vector-sized < 0 # GHC 8.4 via ghc-typelits-knownnat
         - stack < 0 # GHC 8.4 via hackage-security


### PR DESCRIPTION
Now that `ghc-tcplugins-extra-0.2.4` is in nightly:

- `ghc-typelits-natnormalise-0.5.9`, and
- `ghc-typelits-knownnat-0.4.1`

Can be build on GHC 8.4.

- `ghc-typelits-extra-0.2.4` can now also build on GHC 8.4 now that its (transitive) dependencies can build on GHC 8.4

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
