### PR TITLE
Restore `pipes-concurrency`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -763,7 +763,7 @@ packages:
         - pipes-extras
         - pipes-http
         - pipes-parse
-        # - pipes-concurrency # build failure with GHC 8.4 https://github.com/Gabriel439/Haskell-Pipes-Concurrency-Library/issues/47
+        - pipes-concurrency
         - pipes-safe
         - turtle
         - foldl


### PR DESCRIPTION
`pipes-concurrency` should now be GHC-8.4-compatible

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
