### PR TITLE
Re-add gi-gtk, gi-gio, and remove bound on haskell-gi-overloading

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2562,16 +2562,18 @@ packages:
         - sum-type-boilerplate
 
     "Iñaki García Etxebarria <garetxe@gmail.com> @garetxe":
+        - haskell-gi
+        - haskell-gi-base
         - gi-atk
         - gi-cairo
         - gi-glib
+        - gi-gio
         - gi-gobject
+        - gi-gtk
+        - gi-gtk-hs
+        - gi-gtksource
         - gi-javascriptcore
-        - haskell-gi
-        - haskell-gi-base
-        # - gi-gtk-hs # gi-gio fails to build with ghc-8.2
-        # - gi-gtksource # gi-gio fails to build with ghc-8.2
-        # - gi-webkit2 # gi-gio fails to build with ghc-8.2
+        - gi-webkit2
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":
         - directory-tree
@@ -4122,9 +4124,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/3183
         - criterion < 1.4
-
-        # https://github.com/fpco/stackage/issues/3186
-        - haskell-gi-overloading < 1
 
         # https://github.com/fpco/stackage/issues/3337
         - aeson < 1.3


### PR DESCRIPTION
These were removed due to a bug in GHC 8.2.1, and work fine with GHC 8.4.1.

See https://github.com/fpco/stackage/issues/3186 and
https://github.com/haskell-gi/haskell-gi/issues/113 for further
context.