### PR TITLE
Re-add gi-gtk-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2570,7 +2570,7 @@ packages:
         - gi-gio
         - gi-gobject
         - gi-gtk
-        # - gi-gtk-hs # GHC 8.4 via base-4.11.0.0
+        - gi-gtk-hs
         - gi-gtksource
         - gi-javascriptcore
         # - gi-webkit2 # GHC 8.4


### PR DESCRIPTION
There is a new revision of gi-gtk-hs-0.3.5.0 in hackage with a relaxed
upper bound on base, better reflecting reality.
