### PR TITLE
Reenable profiterole as ghc-prof got updated

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3817,7 +3817,6 @@ packages:
         - wrecker < 0 # GHC 8.4 via ansigraph
         - hinotify < 0 # GHC 8.4 via async-2.2.1
         - brick < 0 # GHC 8.4 via base-4.11.0.0
-        - ghc-prof < 0 # GHC 8.4 via base-4.11.0.0
         - hastache < 0 # GHC 8.4 via base-4.11.0.0
         - tasty-hedgehog < 0 # GHC 8.4 via base-4.11.0.0
         - token-bucket < 0 # GHC 8.4 via base-4.11.0.0
@@ -4004,7 +4003,6 @@ packages:
         - genvalidity-text < 0 # GHC 8.4 via genvalidity-hspec
         - genvalidity-time < 0 # GHC 8.4 via genvalidity-hspec
         - genvalidity-uuid < 0 # GHC 8.4 via genvalidity-hspec
-        - profiterole < 0 # GHC 8.4 via ghc-prof
         - follow-file < 0 # GHC 8.4 via hinotify
         - fsnotify < 0 # GHC 8.4 via hinotify
         - ztail < 0 # GHC 8.4 via hinotify


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On CI, in a new VM, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
