### PR TITLE
datadog-0.2.2.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3580,7 +3580,6 @@ packages:
         - Spock-lucid < 0 # GHC 8.4 via Spock
         - MFlow < 0 # GHC 8.4 via TCache
         - Workflow < 0 # GHC 8.4 via TCache
-        - datadog < 0 # GHC 8.4 via buffer-builder
         - hledger < 0 # GHC 8.4 via hledger-lib
         - hledger-interest < 0 # GHC 8.4 via hledger-lib
         - H < 0 # GHC 8.4 via inline-r


### PR DESCRIPTION
Datadog is released as 0.2.2.0, with buffer-builder. Include in build-constraints.yaml.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks