### PR TITLE
Fix tfausak's packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1575,26 +1575,26 @@ packages:
 
     "Taylor Fausak <taylor@fausak.me> @tfausak":
         - autoexporter
-        - bento
-        - bmp
-        # - Chart # Maintained by @timbod7. # build failure with GHC 8.4 https://github.com/timbod7/haskell-chart/issues/181
-        # - Chart-diagrams # lens 4.16 via diagrams # Maintained by @timbod7.
-        # - diagrams-postscript # lens 4.16 # Maintained by @byorgey.
-        - ekg-statsd # Maintained by @tibbe.
+        - derulo
         - flow
         - github-release
-        - gloss # Maintained by @benl23x5.
-        - gloss-rendering # Maintained by @benl23x5.
-        - gpolyline # Maintained by @fegu.
+        - json-feed
         - lackey
-        - monad-memo # Maintained by @EduardSergeev.
-        - postgresql-simple-migration # Maintained by @ameingast.
         - ratel
         - ratel-wai
-        # - rattletrap # text-1.2.3.0
-        - statestack # Maintained by @byorgey.
+        - rattletrap
+        - salve
         - strive
         - wuss
+
+        - bmp # @benl23x5
+        - ekg-statsd # @tibbe
+        - gloss # @benl23x5
+        - gloss-rendering # @benl23x5
+        - gpolyline # @fegu
+        - monad-memo # @EduardSergeev
+        - postgresql-simple-migration # @ameingast
+        - statestack # @byorgey
 
     "Marios Titas <redneb@gmx.com> @redneb":
         - HsOpenSSL-x509-system


### PR DESCRIPTION
- Removed [`bento`](https://hackage.haskell.org/package/bento), which is deprecated.
- Removed comments about [`Chart`](https://hackage.haskell.org/package/Chart), [`Chart-diagrams`](https://hackage.haskell.org/package/Chart-diagrams), and [`diagrams-postscript`](https://hackage.haskell.org/package/diagrams-postscript) libraries since I've lost interest in stewarding them.
- Added [`json-feed`](https://hackage.haskell.org/package/json-feed). 
- Re-enabled [`rattletrap`](https://hackage.haskell.org/package/rattletrap).
- Added [`salve`](https://hackage.haskell.org/package/salve). 
- Sorted all projects maintained by other people below mine in a separate section. 