### PR TITLE
Restore `morte`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3550,7 +3550,6 @@ packages:
         - Spock < 0 # GHC 8.4 via reroute
         - simple < 0 # GHC 8.4 via simple-templates
         - mbtiles < 0 # GHC 8.4 via sqlite-simple
-        - morte < 0 # GHC 8.4 via text-format
         - redis-io < 0 # GHC 8.4 via tinylog
         - axiom < 0 # GHC 8.4 via transient
         - transient-universe < 0 # GHC 8.4 via transient


### PR DESCRIPTION
`morte` no longer depends on `text-format`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
