### PR TITLE
Restore `turtle` and `bench`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3839,7 +3839,6 @@ packages:
         - attoparsec-time < 0 # GHC 8.4 via doctest-0.15.0
         - flow < 0 # GHC 8.4 via doctest-0.15.0
         - hasmin < 0 # GHC 8.4 via doctest-0.15.0
-        - turtle < 0 # GHC 8.4 via doctest-0.15.0
         - eventstore < 0 # GHC 8.4 via ekg-core
         - monad-metrics < 0 # GHC 8.4 via ekg-core
         - wai-middleware-metrics < 0 # GHC 8.4 via ekg-core
@@ -4034,7 +4033,6 @@ packages:
         - tasty-discover < 0 # GHC 8.4 via tasty-hedgehog
         - universum < 0 # GHC 8.4 via tasty-hedgehog
         - wai-middleware-throttle < 0 # GHC 8.4 via token-bucket
-        - bench < 0 # GHC 8.4 via turtle
         - docker-build-cacher < 0 # GHC 8.4 via turtle
         - turtle-options < 0 # GHC 8.4 via turtle
         - normalization-insensitive < 0 # GHC 8.4 via unicode-transforms


### PR DESCRIPTION
`turtle` now builds against the latest version of `doctest`

This also unblocks `bench`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
