### PR TITLE
Unblock concurrent-extra, threads, threads-extra and snap-server

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3568,7 +3568,6 @@ packages:
         - jmacro < 0 # GHC 8.4 via wl-pprint-text
         - yesod-auth-fb < 0 # GHC 8.4 via yesod-fb
         - xturtle < 0 # GHC 8.4 via yjsvg
-        - threads < 0 # GHC 8.4 via concurrent-extra
         - hindent < 0 # GHC 8.4 via descriptive
         - wai-middleware-crowd < 0 # GHC 8.4 via http-reverse-proxy
         - distributed-process < 0 # GHC 8.4 via network-transport-tcp
@@ -3592,7 +3591,6 @@ packages:
         - hedis < 0 # GHC 8.4 via slave-thread
         - distributed-process-monad-control < 0 # GHC 8.4 via distributed-process
         - distributed-process-tests < 0 # GHC 8.4 via distributed-process
-        - threads-extras < 0 # GHC 8.4 via threads
 
         # transitive failures, gen 3
         - persistent-redis < 0 # GHC 8.4 via hedis
@@ -4637,7 +4635,6 @@ expected-test-failures:
     - sourcemap # https://github.com/chrisdone/sourcemap/issues/3
     - text-icu # https://github.com/bos/text-icu/issues/32
     - text-ldap # https://github.com/khibino/haskell-text-ldap/issues/1
-    - threads
     - thyme # https://github.com/liyang/thyme/issues/50
     - tls # https://github.com/vincenthz/hs-tls/issues/247
     - unicode-transforms # https://github.com/harendra-kumar/unicode-transforms/issues/15

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3804,7 +3804,6 @@ packages:
         - web-routes-th < 0 # GHC 8.4 via template-haskell-2.13.0.0
 
         # missed by first wave
-        - snap-server < 0 # GHC 8.4 via base-4.11.0.0
         - Frames < 0 # GHC 8.4 via base-4.11.0.0
         - cryptohash-md5 < 0 # GHC 8.4 via base-4.11.0.0
         - cryptohash-sha1 < 0 # GHC 8.4 via base-4.11.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -131,7 +131,7 @@ packages:
         - calendar-recycling
         - combinatorial
         - comfort-graph
-        - /ent-split
+        - concurrent-split
         - cutter
         - data-accessor
         - data-accessor-mtl

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -131,7 +131,7 @@ packages:
         - calendar-recycling
         - combinatorial
         - comfort-graph
-        - concurrent-split
+        - /ent-split
         - cutter
         - data-accessor
         - data-accessor-mtl
@@ -3453,7 +3453,6 @@ packages:
         - attoparsec-uri < 0 # DependencyFailed (PackageName "attoparsec-ip")
         - binary-tagged < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cli < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - concurrent-extra < 0 # BuildFailureException Process exited with ExitFailure 1: dist/build/test-concurrent-extra/test-concurrent-extra
         - crackNum < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - descriptive < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - git < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

As these packages depend on each other, the above commands fail. But running the tests with cabal works. Except for `concurrent-extra` which has [a failing test](https://github.com/basvandijk/concurrent-extra/issues/12).