### PR TITLE
Re-enable mysql in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3404,7 +3404,6 @@ packages:
         - ini < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - lame < 0 # DependencyFailed (PackageName "htaglib")
         - loch-th < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - mysql < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - ochintin-daicho < 0 # DependencyFailed (PackageName "bookkeeping")
         - pred-set < 0 # DependencyFailed (PackageName "HSet")
         - simple-log < 0 # DependencyFailed (PackageName "hformat")


### PR DESCRIPTION
Version 0.1.5, just released to hackage, builds against nightly-2018-03-20 without any errors or warnings, so I think it should be OK!

[ Checklist carried out, except that tests are omitted for this package. ]