### PR TITLE
vector-sized back in stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3378,7 +3378,6 @@ packages:
         - validity-containers < 0 # build failure with GHC 8.4
         - validity-text < 0 # build failure with GHC 8.4
         - validity-time < 0 # build failure with GHC 8.4
-        - vector-sized < 0 # build failure with GHC 8.4
         - wl-pprint < 0 # build failure with GHC 8.4
         - yjsvg < 0 # build failure with GHC 8.4
 


### PR DESCRIPTION
v1.0.0.0 https://github.com/expipiplus1/vector-sized/pull/35 fixes build issues with ghc 8.4

For some reason this requires adding finite-typelits-0.1.3.0 to extra-deps, since finite-typelits is not in the nightlies currently, despite being able to build fine when I test it with current nightlies?

Thanks!

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
