### PR TITLE
Restore HaTeX

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3383,7 +3383,6 @@ packages:
 
         # round 2:
         - HSet < 0 # DependencyFailed (PackageName "hashtables")
-        - HaTeX < 0 # DependencyFailed (PackageName "matrix")
         - bookkeeping < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cartel < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cases < 0 # DependencyFailed (PackageName "loch-th")


### PR DESCRIPTION
Since matrix was fixed, HaTeX should be building again fine.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
