### PR TITLE
hamilton, hmatrix-vector-sized sized back into stackage nightlies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3557,7 +3557,6 @@ packages:
         - validity-unordered-containers < 0 # GHC 8.4 via validity
         - validity-vector < 0 # GHC 8.4 via validity
         - validity-aeson < 0 # GHC 8.4 via validity-text
-        - hamilton < 0 # GHC 8.4 via vector-sized
         - elm-export < 0 # GHC 8.4 via wl-pprint-text
         - hsx-jmacro < 0 # GHC 8.4 via wl-pprint-text
         - jmacro < 0 # GHC 8.4 via wl-pprint-text
@@ -3829,7 +3828,6 @@ packages:
         - json-schema < 0 # GHC 8.4 via generic-aeson
         - hint < 0 # GHC 8.4 via ghc-8.4.1
         - hmatrix-backprop < 0 # GHC 8.4 via ghc-typelits-knownnat
-        - hmatrix-vector-sized < 0 # GHC 8.4 via ghc-typelits-knownnat
         - stack < 0 # GHC 8.4 via hackage-security
         - pandoc < 0 # GHC 8.4 via haddock-library-1.5.0.1
         - happstack-jmacro < 0 # GHC 8.4 via happstack-server


### PR DESCRIPTION
hamilton-0.1.0.3 fixes build issues; hmatrix-vector-sized back on because vector-sized is back.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
