### PR TITLE
Restore `tz`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3787,7 +3787,6 @@ packages:
         - test-fixture < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - th-to-exp < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - threepenny-gui < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - tz < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - web-routes-th < 0 # GHC 8.4 via template-haskell-2.13.0.0
 
         # missed by first wave


### PR DESCRIPTION
Fixed in nilcons/haskell-tz@9298bca5ee41c8315a3aada4a8f81579858dbf0f

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Building benchmarks fails, but it is disabled for this package anyway. Haddock fails for `haskell-src-exts`.