### PR TITLE
Restore IP but skip tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3446,8 +3446,6 @@ packages:
         - graph-core < 0 # GHC 8.4 via HTF
         - invertible < 0 # GHC 8.4 via TypeCompose
         - apecs < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - attoparsec-ip < 0 # DependencyFailed (PackageName "ip")
-        - attoparsec-uri < 0 # DependencyFailed (PackageName "attoparsec-ip")
         - binary-tagged < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cli < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - crackNum < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3294,7 +3294,6 @@ packages:
         - heap < 0 # build failure with GHC 8.4 https://github.com/pruvisto/heap/issues/5
         - hspec-webdriver < 0 # https://bitbucket.org/wuzzeb/webdriver-utils/issues/9/hspec-webdriver-build-failure-with-ghc-84
         - inline-c < 0 # build failure with GHC 8.4 https://github.com/fpco/inline-c/issues/73
-        - ip < 0 # build failure with GHC 8.4 https://github.com/andrewthad/haskell-ip/issues/34
         - json-builder < 0 # build failure with GHC 8.4 https://github.com/lpsmith/json-builder/issues/2
         - list-t < 0 # build failure with GHC 8.4 # https://github.com/nikita-volkov/list-t/issues/12
         - n-tuple < 0 # build failure with GHC 8.4 https://github.com/athanclark/n-tuple/issues/1
@@ -4291,6 +4290,7 @@ skipped-tests:
     - GLFW-b # HUnit 1.6
     - haskell-tools-refactor # either, tasty, and tasty-hunit
     - hasql-transaction # rebase, see https://github.com/nikita-volkov/rebase/issues/11
+    - ip # hspec 2.5 https://github.com/andrewthad/haskell-ip/issues/33
     - lifted-base # HUnit 1.6
     - makefile # GHC 8.2
     - model # tasty-quickcheck 0.9.2
@@ -4693,7 +4693,6 @@ expected-benchmark-failures:
     - http2
     - xxhash # https://github.com/christian-marie/xxhash/issues/4
     - monad-memo # https://github.com/EduardSergeev/monad-memo/issues/3
-    - ip # https://github.com/andrewthad/haskell-ip/issues/22
     - cmark-gfm # https://github.com/kivikakk/cmark-gfm-hs/issues/5
 
 # end of expected-benchmark-failures


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

n.b. the tests are skipped for now, but the command above passes tests when the constraint on hspec is lifted.