### PR TITLE
Re-enable mysql-simple in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3534,7 +3534,6 @@ packages:
         - stm-containers < 0 # GHC 8.4 via list-t
         - timemap < 0 # GHC 8.4 via list-t
         - groundhog-mysql < 0 # GHC 8.4 via mysql
-        - mysql-simple < 0 # GHC 8.4 via mysql
         - persistent-mysql < 0 # GHC 8.4 via mysql
         - pred-trie < 0 # GHC 8.4 via pred-set
         - rainbox < 0 # GHC 8.4 via rainbow


### PR DESCRIPTION
Was blocked by `mysql`, which is now back in.

[ Checklist completed, but tests are omitted for this package. ]