### PR TITLE
Unblock herms from GHC 8.4.1 build failure list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3967,7 +3967,6 @@ packages:
         - random-shuffle < 0 # GHC 8.4 via MonadRandom
         - random-tree < 0 # GHC 8.4 via MonadRandom
         - vivid < 0 # GHC 8.4 via MonadRandom
-        - herms < 0 # GHC 8.4 via brick
         - hledger-iadd < 0 # GHC 8.4 via brick
         - hledger-ui < 0 # GHC 8.4 via brick
         - Chart-cairo < 0 # GHC 8.4 via cairo


### PR DESCRIPTION
Now that herms dependencies brick and vty are back in action, we've updated our package version constraints and compile fine in 8.4.1!

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
