### PR TITLE
Re-enable persistent-mysql in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3534,7 +3534,6 @@ packages:
         - stm-containers < 0 # GHC 8.4 via list-t
         - timemap < 0 # GHC 8.4 via list-t
         - groundhog-mysql < 0 # GHC 8.4 via mysql
-        - persistent-mysql < 0 # GHC 8.4 via mysql
         - pred-trie < 0 # GHC 8.4 via pred-set
         - rainbox < 0 # GHC 8.4 via rainbow
         - reform-blaze < 0 # GHC 8.4 via reform


### PR DESCRIPTION
This was waiting for `mysql-simple`, which is now in.

[ Checklist completed, except I need to omit haddock on `haskell-src-exts` on my system. ]