### PR TITLE
Restore `hLibsass` and `hSass`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3400,7 +3400,6 @@ packages:
         - glob-posix < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - hdevtools < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - hformat < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - hlibsass < 0 # BuildFailureException Process exited with ExitFailure 1: ghc -clear-package-db -global-package-db -package-db=/var/stackage/work/builds/nightly/pkgdb -hide-all-packages -package=Cabal -package=base -package=directory Setup
         - htaglib < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - ini < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - lame < 0 # DependencyFailed (PackageName "htaglib")
@@ -3520,7 +3519,6 @@ packages:
         - groundhog-mysql < 0 # GHC 8.4 via groundhog
         - groundhog-sqlite < 0 # GHC 8.4 via groundhog
         - groundhog-th < 0 # GHC 8.4 via groundhog
-        - hsass < 0 # GHC 8.4 via hlibsass
         - hocilib < 0 # GHC 8.4 via inline-c
         - inline-c-cpp < 0 # GHC 8.4 via inline-c
         - inline-r < 0 # GHC 8.4 via inline-c


### PR DESCRIPTION
Hello!

I've adapter `hlibsass` to work with GHC 8.4 (and Cabal 2.2 - that was the reason why it didn't build). They should work correctly now (Travis builds with `nightly-2018-03-23`: [hLibsass](https://travis-ci.org/jakubfijalkowski/hlibsass/jobs/357772866) and [hSass](https://travis-ci.org/jakubfijalkowski/hsass/jobs/357772923) ).

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
