### PR TITLE
Reenable netwire and netwire-input.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3463,8 +3463,6 @@ packages:
         - mandrill < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - matplotlib < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - mega-sdist < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - netwire < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - netwire-input < 0 # DependencyFailed (PackageName "netwire")
         - network-transport-tcp < 0 # BuildFailureException Process exited with ExitFailure 1: dist/build/TestTCP/TestTCP
         - package-description-remote < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - pdf-toolbox-content < 0 # DependencyFailed (PackageName "pdf-toolbox-core")


### PR DESCRIPTION
netwire and netwire-input should both be working now with the release of netwire-5.0.3 to hackage.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
