### PR TITLE
Unblocked rank2classes from GHC 8.4 - works with 1.0.2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3768,7 +3768,6 @@ packages:
         - haskell-tools-refactor < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - modern-uri < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - monad-mock < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - rank2classes < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - servant-swagger-ui < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - stache < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - strive < 0 # GHC 8.4 via template-haskell-2.13.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
