### PR TITLE
Unblock nvim-hs-*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2999,7 +2999,7 @@ packages:
     "Sebastian Witte <woozletoff@gmail.com> @saep":
         - nvim-hs
         - nvim-hs-contrib
-        - nvim-hs-ghcid
+          # - nvim-hs-ghcid
 
     "Sam Protas <sam.protas@gmail.com> @SamProtas":
         - triplesec

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2997,10 +2997,9 @@ packages:
         - katip-scalyr-scribe
 
     "Sebastian Witte <woozletoff@gmail.com> @saep":
-        []
-        # - nvim-hs # https://github.com/neovimhaskell/nvim-hs/issues/63
-        # - nvim-hs-contrib # via nvim-hs
-        # - nvim-hs-ghcid # via nvim-hs
+        - nvim-hs
+        - nvim-hs-contrib
+        - nvim-hs-ghcid
 
     "Sam Protas <sam.protas@gmail.com> @SamProtas":
         - triplesec


### PR DESCRIPTION
The issue in neovimhaskell/nvim-hs#63 is fixed.

This reverts commit 6e7bc4ae9bbd869123580d373a7f52869157a218.

FWIW, I added `--nix --no-nix-pure --nix-packages zlib` to the build command in the checklist.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
