### PR TITLE
restore slack-web (now supports base-4.11)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3730,7 +3730,6 @@ packages:
         - servant-server < 0 # GHC 8.4 via base-4.11.0.0
         - servant-swagger < 0 # GHC 8.4 via base-4.11.0.0
         - servant-yaml < 0 # GHC 8.4 via base-4.11.0.0
-        - slack-web < 0 # GHC 8.4 via base-4.11.0.0
         - snap < 0 # GHC 8.4 via base-4.11.0.0
         - spdx < 0 # GHC 8.4 via base-4.11.0.0
         - statestack < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Note that this command failed:

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

ghc-8.4.1 cannot be used for these packages:
    - slack-web
base version 4.11.0.0 found
    - slack-web requires >=4.9 && <4.11

however we now published slack-web 0.2.0.4 which does support base-4.11.

PS: unless I missed it, i wasn't notified that slack-web was disabled :(