### PR TITLE
Re-enable websockets-snap and dependents

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3773,7 +3773,6 @@ packages:
         - strive < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - test-fixture < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - th-to-exp < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - threepenny-gui < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - web-routes-th < 0 # GHC 8.4 via template-haskell-2.13.0.0
 
         # missed by first wave
@@ -3936,8 +3935,6 @@ packages:
         - wrecker < 0 # GHC 8.4 via tdigest
         - syb-with-class < 0 # GHC 8.4 via template-haskell-2.13.0.0
         - type-assertions < 0 # GHC 8.4 via test-fixture
-        - threepenny-editors < 0 # GHC 8.4 via threepenny-gui
-        - threepenny-gui-flexbox < 0 # GHC 8.4 via threepenny-gui
         - MonadRandom < 0 # GHC 8.4 via transformers-compat-0.6.0.6
         - exception-transformers < 0 # GHC 8.4 via transformers-compat-0.6.0.6
         - monad-control-aligned < 0 # GHC 8.4 via transformers-compat-0.6.0.6
@@ -4052,7 +4049,6 @@ packages:
         - lambdabot-irc-plugins < 0 # GHC 8.4 via lambdabot-core
 
         # trans deps, rediscovered.
-        - websockets-snap < 0 # GHC 8.4 via snap-server-1.1.0.0
         - eventstore < 0 # GHC 8.4 via text-format
         - eventstore < 0 # GHC 8.4 via uuid
 


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

At least `websockets-snap` and `threepenny-gui` build fine with the latest nightly.