### PR TITLE
Add persisent-iproute

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3249,6 +3249,7 @@ packages:
 
     "Maximilian Tagher <feedback.tagher@gmail.com> @MaxGabriel":
         - aeson-iproute
+        - persistent-iproute
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Note: I couldn't verify that this compiles with stackage nightly. Compiling `haskell-src-exts-1.20.2` seems to just hang for a long time :(. I'm pretty sure it should be fine, though.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
