### PR TITLE
Reenable giphy-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1032,7 +1032,7 @@ packages:
         - arithmoi
         - friendly-time
         - hashable
-        - haxl
+        # - haxl # https://github.com/facebook/Haxl/issues/57
         - monad-time
         - packdeps
         - recursion-schemes


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

Now that servant is back in nightly and my package is upgraded, it's all playing nicely together again.
