### PR TITLE
Remove transformers-compat from expected-test-failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4354,7 +4354,6 @@ expected-test-failures:
     # GHC 8.4
     - concurrent-extra # https://github.com/basvandijk/concurrent-extra/issues/12
     - doctest # https://github.com/sol/doctest/issues/198
-    - transformers-compat # https://github.com/ekmett/transformers-compat/issues/32
 
 
     # Intermittent failures or unreliable. These tests may pass when


### PR DESCRIPTION
I've just pushed `transformers-compat-0.6.1`, which no longer includes a test suite (see https://github.com/ekmett/transformers-compat/pull/33), so there's no need to include it in `expected-test-failures` anymore.
