### PR TITLE
Protolude fixed under base-4.11 for 0.21 and 0.22

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3695,7 +3695,6 @@ packages:
         - proto-lens-arbitrary < 0 # GHC 8.4 via base-4.11.0.0
         - proto-lens-descriptors < 0 # GHC 8.4 via base-4.11.0.0
         - proto-lens-optparse < 0 # GHC 8.4 via base-4.11.0.0
-        - protolude < 0 # GHC 8.4 via base-4.11.0.0
         - publicsuffix < 0 # GHC 8.4 via base-4.11.0.0
         - pusher-http-haskell < 0 # GHC 8.4 via base-4.11.0.0
         - raaz < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Adds fix for https://github.com/fpco/stackage/issues/3389 for `protolude`. Fixes for the bounds issue are pushed downstream in [protolude-0.21](https://hackage.haskell.org/package/protolude-0.2.1) and [protolude-0.22](https://hackage.haskell.org/package/protolude-0.2.2).