### PR TITLE
Drop upper bound on algebraic-graphs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3994,8 +3994,6 @@ packages:
         # https://github.com/fpco/stackage/issues/3472
         - brick < 0.36
 
-        # https://github.com/fpco/stackage/issues/3474
-        - algebraic-graphs < 0.1.0
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
See #3474

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Note that I slightly deviated from the above checklist. I had to do `stack unpack $package-$version` instead, i.e. `stack unpack algebraic-graphs-0.1.1` as otherwise it downloaded the version `0.1.0`.