### PR TITLE
Add tao and tao-example

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2403,6 +2403,8 @@ packages:
         - logging-effect-extra-file
         - logging-effect-extra-handler
         - overhang
+        - tao
+        - tao-example
 
     "Suhail Shergill <suhailshergill@gmail.com> @suhailshergill":
         - extensible-effects


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack tao
      cd tao-1.0.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

**Note:** `tao-example` depends on `tao` and this PR adds both packages to `build-constraints.yml`. Because `tao` is not on Stackage, I cannot successfully run checklist item 3 for `tao-example`.  If an initial PR of just `tao` is preferred, please let me know.  While `tao-example` depends on `tao`, the only other dep for both `tao` and `tao-example` is `base`, so feels like it should be fine to include both in the same PR.