### PR TITLE
Re-enable xml-isogen

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3519,7 +3519,6 @@ packages:
         - groundhog-sqlite < 0 # GHC 8.4 via direct-sqlite
         - selda-sqlite < 0 # GHC 8.4 via direct-sqlite
         - djinn-ghc < 0 # GHC 8.4 via djinn-lib
-        - xml-isogen < 0 # GHC 8.4 via dom-parser
         - yesod-auth-fb < 0 # GHC 8.4 via fb
         - disposable < 0 # GHC 8.4 via ghcjs-base-stub
         - javascript-extras < 0 # GHC 8.4 via ghcjs-base-stub


### PR DESCRIPTION
xml-isogen was disabled via dom-parser. 
dom-parser was re-enabled in #3429

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
