### PR TITLE
Reinstate `streaming-bytestring`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3442,7 +3442,7 @@ packages:
         - pinch < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - pthread < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - yi-rope < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - streaming-bytestring < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        #- streaming-bytestring < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - HStringTemplate < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - csv-conduit < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - direct-sqlite < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build


### PR DESCRIPTION
Since it builds with the latest nightly (2018 April 5).

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory ... foobar
