### PR TITLE
Relax constraints on `generic-lens`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3993,9 +3993,6 @@ packages:
         # https://github.com/fpco/stackage/issues/3472
         - brick < 0.36
 
-        # https://github.com/kcsongor/generic-lens/issues/43
-        - generic-lens < 1
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of
@@ -4738,9 +4735,6 @@ skipped-benchmarks:
     # @phadej
     - dlist-nonempty # criterion-1.3
     - splitmix# # criterion-1.3
-
-    # https://github.com/kcsongor/generic-lens/issues/42
-    - generic-lens
 
 # end of skipped-benchmarks
 


### PR DESCRIPTION
I've removed the upper bound on `criterion` (https://github.com/kcsongor/generic-lens/issues/42) and fixed the performance tests for 8.4.1 (https://github.com/kcsongor/generic-lens/issues/43)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks