### PR TITLE
fold-debounce-conduit-0.2.0.1 is compatible with base-4.11.0.0 now.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3643,7 +3643,6 @@ packages:
         - extensible-effects < 0 # GHC 8.4 via base-4.11.0.0
         - fast-builder < 0 # GHC 8.4 via base-4.11.0.0
         - feed < 0 # GHC 8.4 via base-4.11.0.0
-        - fold-debounce-conduit < 0 # GHC 8.4 via base-4.11.0.0
         - force-layout < 0 # GHC 8.4 via base-4.11.0.0
         - friday-juicypixels < 0 # GHC 8.4 via base-4.11.0.0
         - generic-random < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
