### PR TITLE
Add `streaming-attoparsec`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -897,13 +897,15 @@ packages:
         - disk-free-space
 
     "Colin Woodbury <colingw@gmail.com> @fosskers":
+        - kanji
         - microlens-aeson
+        - pipes-random
         - repa
         - repa-io
         - repa-algorithms
+        - servant-xml
+        - streaming-attoparsec
         - versions
-        - kanji
-        - pipes-random
         - vectortiles
 
     "Ketil Malde @ketil-malde":
@@ -3676,7 +3678,8 @@ packages:
         - palette < 0 # GHC 8.4 via base-4.11.0.0
         - partial-semigroup < 0 # GHC 8.4 via base-4.11.0.0
         - path-text-utf8 < 0 # GHC 8.4 via base-4.11.0.0
-        - pipes-random < 0 # GHC 8.4 via base-4.11.0.0
+        - perf < 0 # GHC 8.4 via base-4.11.0.0
+        # - pipes-random < 0 # GHC 8.4 via base-4.11.0.0
         - pomaps < 0 # GHC 8.4 via base-4.11.0.0
         - posix-paths < 0 # GHC 8.4 via base-4.11.0.0
         - postgresql-simple < 0 # GHC 8.4 via base-4.11.0.0
@@ -3714,8 +3717,8 @@ packages:
         - vado < 0 # GHC 8.4 via base-4.11.0.0
         - vcswrapper < 0 # GHC 8.4 via base-4.11.0.0
         - vector-fftw < 0 # GHC 8.4 via base-4.11.0.0
-        - vectortiles < 0 # GHC 8.4 via base-4.11.0.0
-        - versions < 0 # GHC 8.4 via base-4.11.0.0
+        #- vectortiles < 0 # GHC 8.4 via base-4.11.0.0
+        #- versions < 0 # GHC 8.4 via base-4.11.0.0
         - wavefront < 0 # GHC 8.4 via base-4.11.0.0
         - apply-refact < 0 # GHC 8.4 via ghc-8.4.1
         - brittany < 0 # GHC 8.4 via ghc-8.4.1
@@ -3823,7 +3826,7 @@ packages:
         - eventsource-geteventstore-store < 0 # GHC 8.4 via protolude
         - eventsource-stub-store < 0 # GHC 8.4 via protolude
         - hpio < 0 # GHC 8.4 via protolude
-        - kanji < 0 # GHC 8.4 via protolude
+        #- kanji < 0 # GHC 8.4 via protolude
         - logger-thread < 0 # GHC 8.4 via protolude
         - teardown < 0 # GHC 8.4 via protolude
         - text-generic-pretty < 0 # GHC 8.4 via protolude

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3674,7 +3674,6 @@ packages:
         - palette < 0 # GHC 8.4 via base-4.11.0.0
         - partial-semigroup < 0 # GHC 8.4 via base-4.11.0.0
         - path-text-utf8 < 0 # GHC 8.4 via base-4.11.0.0
-        # - pipes-random < 0 # GHC 8.4 via base-4.11.0.0
         - pomaps < 0 # GHC 8.4 via base-4.11.0.0
         - posix-paths < 0 # GHC 8.4 via base-4.11.0.0
         - postgresql-simple < 0 # GHC 8.4 via base-4.11.0.0
@@ -3712,8 +3711,6 @@ packages:
         - vado < 0 # GHC 8.4 via base-4.11.0.0
         - vcswrapper < 0 # GHC 8.4 via base-4.11.0.0
         - vector-fftw < 0 # GHC 8.4 via base-4.11.0.0
-        #- vectortiles < 0 # GHC 8.4 via base-4.11.0.0
-        #- versions < 0 # GHC 8.4 via base-4.11.0.0
         - wavefront < 0 # GHC 8.4 via base-4.11.0.0
         - apply-refact < 0 # GHC 8.4 via ghc-8.4.1
         - brittany < 0 # GHC 8.4 via ghc-8.4.1
@@ -3821,7 +3818,6 @@ packages:
         - eventsource-geteventstore-store < 0 # GHC 8.4 via protolude
         - eventsource-stub-store < 0 # GHC 8.4 via protolude
         - hpio < 0 # GHC 8.4 via protolude
-        #- kanji < 0 # GHC 8.4 via protolude
         - logger-thread < 0 # GHC 8.4 via protolude
         - teardown < 0 # GHC 8.4 via protolude
         - text-generic-pretty < 0 # GHC 8.4 via protolude

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -900,10 +900,6 @@ packages:
         - kanji
         - microlens-aeson
         - pipes-random
-        - repa
-        - repa-io
-        - repa-algorithms
-        - servant-xml
         - streaming-attoparsec
         - versions
         - vectortiles
@@ -3678,7 +3674,6 @@ packages:
         - palette < 0 # GHC 8.4 via base-4.11.0.0
         - partial-semigroup < 0 # GHC 8.4 via base-4.11.0.0
         - path-text-utf8 < 0 # GHC 8.4 via base-4.11.0.0
-        - perf < 0 # GHC 8.4 via base-4.11.0.0
         # - pipes-random < 0 # GHC 8.4 via base-4.11.0.0
         - pomaps < 0 # GHC 8.4 via base-4.11.0.0
         - posix-paths < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
This also reinstates some of my other libraries that were blocked due to not building under GHC 8.4.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory ...