### PR TITLE
Renable xxhash-ffi after disabling benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3558,7 +3558,7 @@ packages:
         - distributed-process < 0 # GHC 8.4 via network-transport-tcp
         - distributed-process-lifted < 0 # GHC 8.4 via network-transport-tcp
         - distributed-process-simplelocalnet < 0 # GHC 8.4 via network-transport-tcp
-        - xxhash-ffi < 0 # GHC 8.4 via xxhash
+        # xxhash-ffi < 0 # GHC 8.4 via xxhash
 
         # transitive failures, gen 2
         - MFlow < 0 # GHC 8.4 via RefSerialize

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3506,7 +3506,7 @@ packages:
         - xlsx-tabular < 0 # DependencyFailed (PackageName "xlsx")
         - xmonad < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - xmonad-contrib < 0 # DependencyFailed (PackageName "xmonad")
-        - xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        # xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
 
 
         # Transitive failures, reported on https://github.com/fpco/stackage/issues/3394

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3558,7 +3558,6 @@ packages:
         - distributed-process < 0 # GHC 8.4 via network-transport-tcp
         - distributed-process-lifted < 0 # GHC 8.4 via network-transport-tcp
         - distributed-process-simplelocalnet < 0 # GHC 8.4 via network-transport-tcp
-        # xxhash-ffi < 0 # GHC 8.4 via xxhash
 
         # transitive failures, gen 2
         - MFlow < 0 # GHC 8.4 via RefSerialize
@@ -4653,6 +4652,7 @@ skipped-benchmarks:
     # ghc 8.4 outdated dependencies
     - buffer-builder # ghc 8.4 via json-builder build failure
     - psqueues # ghc 8.4 via PSQueue build failure
+    - xxhash-ffi # ghc 8.4 via xxhash build failure
 
     # Transitive outdated dependencies
     # These packages

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3506,7 +3506,7 @@ packages:
         - xlsx-tabular < 0 # DependencyFailed (PackageName "xlsx")
         - xmonad < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - xmonad-contrib < 0 # DependencyFailed (PackageName "xmonad")
-        # xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        - xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
 
 
         # Transitive failures, reported on https://github.com/fpco/stackage/issues/3394


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, ...

   Note: This only works when using the following build command, as benchmark building should be disabled due to a missing dependency.

  ```
   stack build --resolver nightly --haddock --no-bench --test 
   ```