### PR TITLE
Reenable ekg-wai

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3634,7 +3634,6 @@ packages:
         - cryptohash-sha512 < 0 # GHC 8.4 via base-4.11.0.0
         - css-syntax < 0 # GHC 8.4 via base-4.11.0.0
         - dictionaries < 0 # GHC 8.4 via base-4.11.0.0
-        - ekg-wai < 0 # GHC 8.4 via base-4.11.0.0
         - euler-tour-tree < 0 # GHC 8.4 via base-4.11.0.0
         - exhaustive < 0 # GHC 8.4 via base-4.11.0.0
         - extensible-effects < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Bounds fixed on hackage

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
