### PR TITLE
re-enable wild-bind and wild-bind-x11

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3421,8 +3421,6 @@ packages:
         - strict-types < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - units-parser < 0 # BuildFailureException Process exited with ExitFailure 1: dist/build/main/main
         - varying < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - wild-bind < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - wild-bind-x11 < 0 # DependencyFailed (PackageName "wild-bind")
         - xls < 0 # DependencyFailed (PackageName "getopt-generics")
         - highjson < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - model < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build


### PR DESCRIPTION
latest wild-bind and wild-bind-x11 are now compatible with base-4.11.0.0

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
