### PR TITLE
Add saltine

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2371,6 +2371,7 @@ packages:
 
     "Hans-Christian Esperer <hc@hcesperer.org> @hce":
         - avwx
+        - saltine
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":


### PR DESCRIPTION
saltine is a haskell binding to the libsodium library, a modern cryptographic
library with simplicity, safety and ease of use as primary goals.

I'm not the author of the library, but briefly exchanged e-mails with the maintainer and
he is fine with me adding his package to stackage.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
