### PR TITLE
Install libsodium-dev

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2376,6 +2376,7 @@ packages:
 
     "Hans-Christian Esperer <hc@hcesperer.org> @hce":
         - avwx
+        - saltine
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -245,6 +245,14 @@ curl https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-l
     && rm libtensorflow.tar.gz \
     && ldconfig
 
+# Install libsodium
+curl https://download.libsodium.org/libsodium/releases/LATEST.tar.gz > libsodium.tar.gz \
+	&& sudo tar xfz libsodium.tar.gz -C /tmp \
+	&& rm libsodium.tar.gz \
+	&& cd /tmp/libsodium-stable \
+	&& ./configure \
+	&& make install
+
 # NOTE: also update Dockerfile when cuda version changes
 # Install CUDA toolkit
 # The current version can be found at: https://developer.nvidia.com/cuda-downloads


### PR DESCRIPTION
Added lines to debian-bootstrap.sh to download, compile and install the latest libsodium
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
