### PR TITLE
Add closed library

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3286,6 +3286,9 @@ packages:
     "Kofi Gumbs <h.kofigumbs@gmail.com> @hkgumbs":
         - codec-beam
 
+    "Chris Parks <christopher.daniel.parks@gmail.com> @cdparks":
+        - closed
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
`closed` is a library for natural numbers with type-level lower and upper bounds. We use this at Front Row.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

NB - I had to build `haskell-src-exts` with `--no-haddock-hyperlink-source`, and I haven't tracked down why, but `closed` itself builds fine.