### PR TITLE
Reenable invertible

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2887,7 +2887,7 @@ packages:
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed < 0 # GHC 8.4 via uuid
-        - invertible < 0 # GHC 8.4 via TypeCompose
+        - invertible
         - ztail
         - zip-stream
 


### PR DESCRIPTION
Disabled default optional dependency on TypeCompose in 0.2.0.5

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
