### PR TITLE
Reenable scotty and wai-middleware-static

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -641,8 +641,8 @@ packages:
         - zlib-lens
 
     "Andrew Farmer <afarmer@ittc.ku.edu> @xich":
-        - scotty < 0.11.1 # due to hpc-coveralls dep
-        - wai-middleware-static < 0 # DependencyFailed (PackageName "hpc-coveralls")
+        - scotty
+        - wai-middleware-static
 
     "Simon Hengel <sol@typeful.net> @sol":
         - hspec
@@ -3513,6 +3513,9 @@ package-flags:
 
     cabal-install:
         lib: true
+
+    scotty:
+        hpc-coveralls: false
 
 # end of package-flags
 


### PR DESCRIPTION
* The latest version of `wai-middleware-static`, 0.8.2, does not depend on `hpc-coveralls`.
* The latest version of `scotty`, 0.11.1, has a `Cabal` flag for disabling the `hpc-coveralls` dependency (I've done so in `build-constraints.yaml`).

(Note: I co-maintain these two packages.)