### PR TITLE
Add `mwc-probability-transition`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -240,6 +240,7 @@ packages:
     "Marco Zocca @ocramz":
         - sparse-linear-algebra
         - matrix-market-attoparsec
+        - mwc-probability-transition
         - network-multicast
         - xeno
         - goggles


### PR DESCRIPTION
`logging-effect`, one of the dependencies, is not on Stackage. I have contacted its author, @ocharles , about it



Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
