### PR TITLE
bv-little-0.1.1 is compatible with GHC-8.4.2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3271,7 +3271,7 @@ packages:
         - starter < 0 # GHC 8.4 via fsnotify
 
     "Alex Washburn <github@recursion.ninja> @recursion-ninja":
-        - bv-little < 0 # GHC 8.4.2 bounds
+        - bv-little
 
     "Avi Press <mail@avi.press> @aviaviavi":
         - curl-runnings


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
