### PR TITLE
Confirmed compatibility of crypto-enigma 0.0.2.11 with GHC 8.4.2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2867,7 +2867,7 @@ packages:
         - hledger-iadd < 0 # GHC 8.4.2 bounds
 
     "Roy Levien <royl@aldaron.com> @orome":
-        - crypto-enigma < 0 # GHC 8.4.2 bounds
+        - crypto-enigma
 
     "Boldizsár Németh <nboldi@elte.hu> @nboldi":
         - instance-control


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

See #3539