### PR TITLE
Re-enable stack and its dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -275,7 +275,7 @@ packages:
         - monad-recorder
         - packcheck
         - streamly
-        - unicode-transforms < 0 # GHC 8.4 via getopt-generics, QuickCheck-2.11.3
+        - unicode-transforms
         - xls < 0 # DependencyFailed (PackageName "getopt-generics")
 
     "Aleksey Uimanov <s9gf4ult@gmail.com> @s9gf4ult":
@@ -1062,7 +1062,7 @@ packages:
         - optparse-simple
         - hpack
         - bindings-uname
-        - stack < 0 # GHC 8.4 via regex-applicative-text
+        - stack
 
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
         - th-orphans
@@ -1263,7 +1263,7 @@ packages:
 
     "Sönke Hahn <soenkehahn@gmail.com> @soenkehahn":
         - generics-eot
-        - getopt-generics < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        - getopt-generics
         - graph-wrapper
         - string-conversions
         - hspec-checkers
@@ -1292,7 +1292,7 @@ packages:
         # - monad-http # http-types 0.12
         - postgresql-simple-url
         - range-set-list < 0 # GHC 8.4 via base-4.11.0.0
-        - regex-applicative-text < 0 # GHC 8.4 via base-4.11.0.0
+        - regex-applicative-text
         - servant-swagger-ui < 0 # GHC 8.4 via transformers-compat-0.6.0.6
         - servant-yaml < 0 # GHC 8.4 via base-4.11.0.0
         - singleton-bool


### PR DESCRIPTION
I only re-enabled the minimum set of packages needed for `stack`, but based on those it may be possible to re-enable other packages that were disabled due to `getopt-generics` and `QuickCheck`.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

  **I did a variant of the above, where I had to add the other packages I re-enabled to the extra-deps for `stack`.**