### PR TITLE
Re-enable ctrie

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2269,7 +2269,7 @@ packages:
         - ekg
 
     "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":
-        - ctrie < 0 # GHC 8.4 via random-shuffle
+        - ctrie
         - ttrie
 
     "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":


### PR DESCRIPTION
One of the `ctrie` benchmarks depends on `random-shuffle` which was temporarily out of the nightlies but is now back.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks