### PR TITLE
wl-pprint-console and colorful-monoids: Removed ghc 8.4 constraints

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2739,13 +2739,13 @@ packages:
         - writer-cps-lens
         - writer-cps-full
         - wl-pprint-annotated
-        - wl-pprint-console < 0 # GHC 8.4 via colorful-monoids
+        - wl-pprint-console
         - console-style
         - unlit
         - intro
         - tasty-auto
         - tasty-stats
-        - colorful-monoids < 0 # build failure with GHC 8.4
+        - colorful-monoids
         - ihs
 
     "Taras Serduke <taras.serduke@gmail.com> @tserduke":


### PR DESCRIPTION
New version released on hackage which fixes the issue with Semigroup/Monoid.