### PR TITLE
Re-enable packages maintained by ocharles

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1889,12 +1889,12 @@ packages:
         - Network-NineP
 
     "Oliver Charles <ollie@ocharles.org.uk> @ocharles":
-        - diff3 < 0 # build failure with GHC 8.4
-        - exhaustive < 0 # GHC 8.4 via base-4.11.0.0
-        - libsystemd-journal < 0 # GHC 8.4 via base-4.11.0.0
-        - network-carbon < 0 # GHC 8.4 via base-4.11.0.0
-        - tasty-rerun < 0 # GHC 8.4 via base-4.11.0.0
-        - logging-effect < 0 # GHC 8.4 via base-4.11.0.0
+        - diff3
+        - exhaustive
+        - libsystemd-journal
+        - network-carbon
+        - tasty-rerun
+        - logging-effect
         # - reactive-banana # pqueue-1.4.1
 
     "Antoni Silvestre <antoni.silvestre@gmail.com> @asilvestre":


### PR DESCRIPTION
I've updated these packages for GHC 8.4 support.

I haven't been able to use the Stack instructions as I'm on NixOS and my channel doesn't have GHC 8.4.2. If anyone knows how I should test this, I'm all ears. I've developed each package with GHC 8.4.1 though.