### PR TITLE
inline-c is GHC 8.4 ready

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2264,8 +2264,8 @@ packages:
         - webdriver
 
     "Luke Iannini <lukexi@me.com> @lukexi":
-        - inline-c < 0 # build failure with GHC 8.4 https://github.com/fpco/inline-c/issues/73
-        - inline-c-cpp < 0 # GHC 8.4 via inline-c
+        - inline-c
+        - inline-c-cpp
         - ekg
 
     "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since [Hackage upload](https://hackage.haskell.org/package/inline-c-0.6.0.6/reports/1)
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
