### PR TITLE
Re-added `plot-light`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -244,7 +244,7 @@ packages:
         - network-multicast
         - xeno
         - goggles
-        - plot-light < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        - plot-light
         - mapquest-api
 
     "Joseph Canero <jmc41493@gmail.com> @caneroj1":


### PR DESCRIPTION
The latest upstream version of plot-light builds and tests correctly against `nightly-2018-05-02`

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
