### PR TITLE
Add chronologique

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2093,6 +2093,7 @@ packages:
         - openssl-streams
 
     "Andrew Cowie <andrew@operationaldynamics.com> @afcowie":
+        - chronologique
         - http-common
         - http-streams
 


### PR DESCRIPTION
Small adapter library with instances and parsing for a timestamp type , tested with current `lts` and `nightly`.

AfC

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully tested:

      stack unpack chronologique-0.3.1.1
      cd chronologique-0.3.1.1
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
