### PR TITLE
exception-transformers 0.4.0.7 works with Stackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3374,7 +3374,6 @@ packages:
         - attoparsec-time < 0 # GHC 8.4 via doctest-0.15.0
         - hint < 0 # GHC 8.4 via ghc-8.4.1
         - syb-with-class < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - exception-transformers < 0 # GHC 8.4 via transformers-compat-0.6.0.6
         - exception-mtl < 0 # GHC 8.4 via exception-transformers
         - consul-haskell < 0 # GHC 8.4 via uuid
         - hasql-transaction < 0 # GHC 8.4 via hasql


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I'm not very familiar with Stackage, and I found the documentation confusing.  What else is required for bringing exception-transformers back to Stackage (or specifically, the packages that depend on it)?