### PR TITLE
stylish-haskell works with GHC 8.4 as of 0.9.1.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -454,7 +454,7 @@ packages:
     "Jasper Van der Jeugt @jaspervdj":
         - blaze-html
         - blaze-markup
-        - stylish-haskell < 0 # BuildFailureException with GHC 8.4
+        - stylish-haskell
         # - profiteur # js-jquery 3.3
         - psqueues
         - websockets


### PR DESCRIPTION
see: https://github.com/jaspervdj/stylish-haskell/pull/204

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
