### PR TITLE
Add back proto-lens-*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2994,14 +2994,14 @@ packages:
         - hslua-aeson
 
     "Judah Jacobson <judah.jacobson@gmail.com> @judah":
-        - lens-labels < 0 # GHC 8.4 via base-4.11.0.0
-        # - proto-lens-combinators # haskell-src-exts via proto-lens-protoc
-        # - proto-lens-protobuf-types # haskell-src-exts via proto-lens-protoc
-        # - proto-lens-protoc # haskell-src-exts
-        - proto-lens < 0 # GHC 8.4 via base-4.11.0.0
-        - proto-lens-arbitrary < 0 # GHC 8.4 via base-4.11.0.0
-        - proto-lens-descriptors < 0 # GHC 8.4 via base-4.11.0.0
-        - proto-lens-optparse < 0 # GHC 8.4 via base-4.11.0.0
+        - lens-labels
+        - proto-lens-combinators
+        - proto-lens-protobuf-types
+        - proto-lens-protoc
+        - proto-lens
+        - proto-lens-arbitrary
+        - proto-lens-descriptors
+        - proto-lens-optparse
         - tensorflow-test
 
     "Christof Schramm <christof.schramm@campus.lmu.de>":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3000,7 +3000,6 @@ packages:
         - proto-lens-protoc
         - proto-lens
         - proto-lens-arbitrary
-        - proto-lens-descriptors
         - proto-lens-optparse
         - tensorflow-test
 


### PR DESCRIPTION
New versions have been released to Hackage which build against stack-nightly.

Also remove `proto-lens-descriptors` which was merged into `proto-lens`.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
