### PR TITLE
Re-enable exception-mtl.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3392,7 +3392,7 @@ packages:
         - attoparsec-time < 0 # GHC 8.4 via doctest-0.15.0
         - hint < 0 # GHC 8.4 via ghc-8.4.1
         - syb-with-class < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - exception-mtl < 0 # GHC 8.4 via exception-transformers
+        - exception-mtl
         - consul-haskell < 0 # GHC 8.4 via uuid
         - hasql-transaction < 0 # GHC 8.4 via hasql
         - language-ecmascript < 0 # wl-pprint


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

The missing checkmark is because one dependency (exception-transformers) is in Stackage HEAD, but not nightly yet.  I tested it by creating a `stack.yaml` in the `exception-mtl-0.4.0.1` directory and adding exception-transformers as an `extra-deps` (what's the usual procedure here?):

```
resolver: nightly-2018-05-09

extra-deps:
- exception-transformers-0.4.0.7
```