### PR TITLE
Re-enable dependents of exception-transformers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1261,7 +1261,7 @@ packages:
         # - magicbane # https://github.com/myfreeweb/magicbane/issues/9
 
     "Francesco Mazzoli <f@mazzo.li> @bitonic":
-        - language-c-quote < 0 # GHC 8.4 via exception-transformers
+        - language-c-quote
 
     "Sönke Hahn <soenkehahn@gmail.com> @soenkehahn":
         - generics-eot
@@ -3378,7 +3378,6 @@ packages:
         - crackNum < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - prim-array < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - quickcheck-classes < 0 # DependencyFailed (PackageName "prim-array")
-        - srcloc < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - xmonad < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - Unique < 0 # GHC 8.4 via base-4.11.0.0
@@ -3392,11 +3391,9 @@ packages:
         - attoparsec-time < 0 # GHC 8.4 via doctest-0.15.0
         - hint < 0 # GHC 8.4 via ghc-8.4.1
         - syb-with-class < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - exception-mtl < 0 # GHC 8.4 via exception-transformers
         - consul-haskell < 0 # GHC 8.4 via uuid
         - hasql-transaction < 0 # GHC 8.4 via hasql
         - language-ecmascript < 0 # wl-pprint
-        - mainland-pretty < 0
 
     "GHC upper bounds":
         # Need to always match the version shipped with GHC


### PR DESCRIPTION
This re-enables the packages language-c-quote, srcloc, exception-mtl,
and mainland-pretty.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload

I did not test this the usual way because exception-transformers is in Stackage HEAD, but not nightly yet. I tested it by creating a stack.yaml in the `language-c-quote-0.12.2` directory and adding the other packages as an extra-deps (what's the usual procedure here?):

```
resolver: nightly-2018-05-09

extra-deps:
- exception-transformers-0.4.0.7
- exception-mtl-0.4.0.1
- mainland-pretty-0.7
- srcloc-0.5.1.2
- symbol-0.2.4
```

(This pull request subsumes #3604.)