### PR TITLE
Do not skip building simple-vec3 benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4122,7 +4122,6 @@ skipped-benchmarks:
     - cryptohash-sha512 # criterion 1.2
     - heist # criterion 1.3
     - pipes # optparse-applicative 0.13
-    - simple-vec3 # via criterion-1.4.1.0
     - splitmix # criterion 1.3
     - superbuffer # criterion 1.3
     - ttrie # criterion-plus and th-pprint


### PR DESCRIPTION
simple-vec3-0.4.0.3 bumped criterion dependency

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
