### PR TITLE
Unconstrain clash-lang packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1673,8 +1673,8 @@ packages:
         - ghc-typelits-knownnat
         - ghc-typelits-natnormalise
         - clash-prelude
-        - clash-lib < 0 # via aeson-1.3.1.0
-        - clash-ghc < 0 # via clash-lib
+        - clash-lib
+        - clash-ghc
 
     "Athan Clark <athan.clark@gmail.com> @athanclark":
         - aeson-attoparsec
@@ -3431,9 +3431,6 @@ packages:
         - hmatrix-gsl < 0.19
         - hmatrix-special < 0.19
 
-        # https://github.com/fpco/stackage/issues/3544
-        - ghc-typelits-natnormalise < 0.6
-
         # https://github.com/fpco/stackage/issues/3559
         - parser-combinators < 1.0
 
@@ -3451,11 +3448,6 @@ packages:
 
         # https://github.com/fpco/stackage/issues/3596
         - brick < 0.37
-
-        # https://github.com/fpco/stackage/issues/3597
-        - ghc-typelits-knownnat < 0.5
-        - ghc-tcplugins-extra < 0.3 # https://github.com/fpco/stackage/issues/3599
-        - ghc-typelits-extra < 0.2.5
 
         # https://github.com/fpco/stackage/issues/3608
         - wl-pprint-text < 1.2


### PR DESCRIPTION
The released packages:

* clash-ghc-0.99.1
* clash-lib-0.99.1
* clash-prelude-0.99.1
* ghc-tcplugins-extra-0.3
* ghc-typelits-knownnat-0.5
* ghc-typelits-natnormalise-0.6.1

have compatible version bounds. 
Additionally, clash-lib has increased its upper bound for `aeson`, and builds on with `aeson-0.1.3.0`

Fixes #3544
Fixes #3597
Fixes #3599

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
