### PR TITLE
Unblock `ihaskell` and `ipython-kernel`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1965,7 +1965,7 @@ packages:
         - apply-refact < 0 # GHC 8.4 via ghc-8.4.1
 
     "Andrew Gibiansky <andrew.gibiansky@gmail.com> @gibiansky":
-        - ipython-kernel < 0 # GHC 8.4 via uuid
+        - ipython-kernel
 
     "Andrés Sicard-Ramírez <asr@eafit.edu.co> @asr":
         - Agda < 0 # GHC 8.4 via template-haskell-2.13.0.0
@@ -3237,7 +3237,7 @@ packages:
         - servant-exceptions
 
     "Vaibhav Sagar <vaibhavsagar@gmail.com> @vaibhavsagar":
-        - ihaskell < 0 # GHC 8.4 via ghc-boot-8.4.1
+        - ihaskell
         - ghc-parser
 
     "Alexis Williams <alexis@typedr.at> @typedrat":


### PR DESCRIPTION
I see that there is now a [revision for `uuid`](http://hackage.haskell.org/package/uuid-1.3.13/revisions/).

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
