### PR TITLE
aeson-diff is compatible again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2958,7 +2958,7 @@ packages:
         - tsv2csv
 
     "Thomas Sutton <me@thomas-sutton.id.au> @thsutton":
-        - aeson-diff < 0 # GHC 8.4 via base-4.11.0.0
+        - aeson-diff
         - edit-distance-vector
 
     "Kyle Van Berendonck <kvanberendonck+stackage@gmail.com> @donkeybonks":
@@ -4034,7 +4034,6 @@ expected-test-failures:
     # Linting failures (these may break every time HLint gets updated so keep them disabled)
     # https://www.snoyman.com/blog/2017/11/future-proofing-test-suites
     - folds
-    - aeson-diff
 
     - servant-swagger
 # end of expected-test-failures


### PR DESCRIPTION
- `aeson-diff` builds again under lts-7, lts-8, lts-9, and nightly resolvers.
- `aeson-diff` no longer uses HLint.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks